### PR TITLE
Fix a handful of bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # avro-builder changelog
 
+## v0.3.2
+- Fix a bug that allowed the partial matching of filenames.
+- Fix a bug that prevented namespace from being specified as an option on
+  records.
+- Fix a bug that prevented loading references qualified by namespace.
+- Do not attempt to import schema files for builtin types.
+
 ## v0.3.1
 - A `null` default should automatically be added for optional fields to match
   the `:null` first member of the union.

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -58,7 +58,7 @@ module Avro
       end
 
       # Lookup an Avro schema object by name, possibly fully qualified by namespace.
-      def lookup(key, required: true)
+      def lookup(key)
         key_str = key.to_s
         object = schema_objects[key_str]
 
@@ -67,11 +67,8 @@ module Avro
           object = schema_objects[key_str]
         end
 
-        raise "Schema object #{key} not found" if required && !object
+        raise "Schema object #{key} not found" unless object
         object
-      rescue
-        raise if required
-        nil
       end
 
       # Return the last schema object processed as a Hash representing
@@ -113,7 +110,7 @@ module Avro
 
       def build_record(name, options, &block)
         Avro::Builder::Types::RecordType
-          .new(name, options.merge(namespace: namespace)).tap do |record|
+          .new(name, { namespace: namespace }.merge(options)).tap do |record|
             record.builder = builder
             record.instance_eval(&block)
           end

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -47,18 +47,8 @@ module Avro
         type(name, :fixed, size_option.merge(options), &block)
       end
 
-      def type(name, type_name, options = {}, &block)
-        build_type(type_name,
-                   builder: self,
-                   internal: { name: name, namespace: namespace },
-                   options: options,
-                   &block).tap do |type|
-          add_schema_object(type)
-        end
-      end
-
       # Lookup an Avro schema object by name, possibly fully qualified by namespace.
-      def lookup(key)
+      def lookup_named_type(key)
         key_str = key.to_s
         object = schema_objects[key_str]
 
@@ -106,6 +96,16 @@ module Avro
         @last_object = object
         schema_objects[object.name.to_s] = object
         schema_objects[object.fullname] = object if object.namespace
+      end
+
+      def type(name, type_name, options = {}, &block)
+        create_and_configure_builtin_type(type_name,
+                                          builder: self,
+                                          internal: { name: name, namespace: namespace },
+                                          options: options,
+                                          &block).tap do |type|
+          add_schema_object(type)
+        end
       end
 
       def build_record(name, options, &block)

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -39,12 +39,12 @@ module Avro
       ## DSL methods for Types
 
       def enum(name, *symbols, **options, &block)
-        type(name, :enum, { symbols: symbols }.merge(options), &block)
+        create_named_type(name, :enum, { symbols: symbols }.merge(options), &block)
       end
 
       def fixed(name, size = nil, options = {}, &block)
         size_option = size.is_a?(Hash) ? size : { size: size }
-        type(name, :fixed, size_option.merge(options), &block)
+        create_named_type(name, :fixed, size_option.merge(options), &block)
       end
 
       # Lookup an Avro schema object by name, possibly fully qualified by namespace.
@@ -98,7 +98,7 @@ module Avro
         schema_objects[object.fullname] = object if object.namespace
       end
 
-      def type(name, type_name, options = {}, &block)
+      def create_named_type(name, type_name, options = {}, &block)
         create_and_configure_builtin_type(type_name,
                                           builder: self,
                                           internal: { name: name, namespace: namespace },

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -30,10 +30,14 @@ module Avro
           send(key, value) if has_dsl_attribute?(key)
         end
 
-        @type = build_type(type_name,
-                           field: self,
-                           internal: internal,
-                           options: options) || builder.lookup(type_name)
+        @type = if builtin_type?(type_name)
+                  create_and_configure_builtin_type(type_name,
+                                                    field: self,
+                                                    internal: internal,
+                                                    options: options)
+                else
+                  builder.lookup_named_type(type_name)
+                end
 
         # DSL calls must be evaluated after the type has been constructed
         instance_eval(&block) if block_given?

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -30,8 +30,10 @@ module Avro
           send(key, value) if has_dsl_attribute?(key)
         end
 
-        @type = builder.lookup(type_name, required: false) ||
-          build_type(type_name, field: self, internal: internal, options: options)
+        @type = build_type(type_name,
+                           field: self,
+                           internal: internal,
+                           options: options) || builder.lookup(type_name)
 
         # DSL calls must be evaluated after the type has been constructed
         instance_eval(&block) if block_given?

--- a/lib/avro/builder/file_handler.rb
+++ b/lib/avro/builder/file_handler.rb
@@ -22,6 +22,10 @@ module Avro
       private
 
       def find_file(name)
+        # Ensure that the file_name that is searched for begins with a slash (/)
+        # and ends with a .rb extension. Additionally, if the name contains
+        # a namespace then ensure that periods (.) are replaced by forward
+        # slashes. E.g. for 'test.example' search for '/test/example.rb'.
         file_name = "/#{name.to_s.gsub('.', '/').sub(/^\//, '').sub(/\.rb$/, '')}.rb"
         matches = self.class.load_paths.flat_map do |load_path|
           Dir["#{load_path}/**/*.rb"].select do |file_path|

--- a/lib/avro/builder/file_handler.rb
+++ b/lib/avro/builder/file_handler.rb
@@ -22,14 +22,14 @@ module Avro
       private
 
       def find_file(name)
-        file_name = "#{name.to_s.sub(/\.rb$/, '')}.rb"
+        file_name = "/#{name.to_s.gsub('.', '/').sub(/^\//, '').sub(/\.rb$/, '')}.rb"
         matches = self.class.load_paths.flat_map do |load_path|
           Dir["#{load_path}/**/*.rb"].select do |file_path|
             file_path.end_with?(file_name)
           end
         end
         raise "Multiple matches: #{matches}" if matches.size > 1
-        raise "File not found #{name}" if matches.empty?
+        raise "File not found #{file_name}" if matches.empty?
 
         matches.first
       end

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -4,35 +4,43 @@ module Avro
     # This concern is used by classes that create new Type instances.
     module TypeFactory
 
-      SPECIFIC_TYPES = Set.new(%w(Array Enum Fixed Map Record Union).map(&:freeze)).freeze
+      COMPLEX_TYPES = Set.new(%w(array enum fixed map record union).map(&:freeze)).freeze
+      BUILTIN_TYPES = Avro::Schema::PRIMITIVE_TYPES.union(COMPLEX_TYPES).freeze
 
       private
 
-      # Return a new Type instance or nil
-      def create_type(type_name)
+      # Return a new Type instance
+      def create_builtin_type(type_name)
+        name = type_name.to_s.downcase
         case
-        when Avro::Schema::PRIMITIVE_TYPES_SYM.include?(type_name.to_sym)
-          Avro::Builder::Types::Type.new(type_name)
+        when Avro::Schema::PRIMITIVE_TYPES.include?(name)
+          Avro::Builder::Types::Type.new(name)
+        when COMPLEX_TYPES.include?(name)
+          Avro::Builder::Types.const_get("#{name.capitalize}Type").new
         else
-          type_class_name = "#{type_name.to_s.capitalize}"
-          if SPECIFIC_TYPES.include?(type_class_name)
-            Avro::Builder::Types.const_get("#{type_class_name}Type").new
-          end
+          raise "Invalid builtin type: #{type_name}"
         end
       end
 
       # Return a new Type instance, including propagating internal state
       # and setting attributes via the DSL
-      def build_type(type_name, field: nil, builder: nil, internal: {}, options: {}, &block)
-        new_type = create_type(type_name)
-        new_type.tap do |type|
+      def create_and_configure_builtin_type(type_name,
+                                            field: nil,
+                                            builder: nil,
+                                            internal: {},
+                                            options: {},
+                                            &block)
+        create_builtin_type(type_name).tap do |type|
           type.field = field
           type.builder = builder
           type.configure_options(internal.merge(options))
           type.instance_eval(&block) if block_given?
-        end if new_type
+        end
       end
 
+      def builtin_type?(type_name)
+        BUILTIN_TYPES.include?(type_name.to_s)
+      end
     end
   end
 end

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -4,28 +4,33 @@ module Avro
     # This concern is used by classes that create new Type instances.
     module TypeFactory
 
+      SPECIFIC_TYPES = Set.new(%w(Array Enum Fixed Map Record Union).map(&:freeze)).freeze
+
       private
 
-      # Return a new Type instance
+      # Return a new Type instance or nil
       def create_type(type_name)
         case
         when Avro::Schema::PRIMITIVE_TYPES_SYM.include?(type_name.to_sym)
           Avro::Builder::Types::Type.new(type_name)
         else
-          type_class_name = "#{type_name.to_s.capitalize}Type"
-          Avro::Builder::Types.const_get(type_class_name).new
+          type_class_name = "#{type_name.to_s.capitalize}"
+          if SPECIFIC_TYPES.include?(type_class_name)
+            Avro::Builder::Types.const_get("#{type_class_name}Type").new
+          end
         end
       end
 
       # Return a new Type instance, including propagating internal state
       # and setting attributes via the DSL
       def build_type(type_name, field: nil, builder: nil, internal: {}, options: {}, &block)
-        create_type(type_name).tap do |type|
+        new_type = create_type(type_name)
+        new_type.tap do |type|
           type.field = field
           type.builder = builder
           type.configure_options(internal.merge(options))
           type.instance_eval(&block) if block_given?
-        end
+        end if new_type
       end
 
     end

--- a/lib/avro/builder/types.rb
+++ b/lib/avro/builder/types.rb
@@ -1,5 +1,5 @@
 require 'avro/builder/types/type'
-require 'avro/builder/types/specific_type'
+require 'avro/builder/types/complex_type'
 require 'avro/builder/types/configurable_type'
 require 'avro/builder/types/type_referencer'
 require 'avro/builder/types/named_type'

--- a/lib/avro/builder/types/array_type.rb
+++ b/lib/avro/builder/types/array_type.rb
@@ -2,13 +2,13 @@ module Avro
   module Builder
     module Types
       class ArrayType < Type
-        include Avro::Builder::Types::SpecificType
+        include Avro::Builder::Types::ComplexType
         include Avro::Builder::Types::ConfigurableType
         include Avro::Builder::Types::TypeReferencer
 
         dsl_attribute :items do |items_type = nil|
           if items_type
-            @items = find_or_create_type(items_type)
+            @items = create_builtin_or_lookup_named_type(items_type)
           else
             @items
           end

--- a/lib/avro/builder/types/complex_type.rb
+++ b/lib/avro/builder/types/complex_type.rb
@@ -2,9 +2,9 @@ module Avro
   module Builder
     module Types
 
-      # This module provides common functionality for Types with a specific
-      # type name vs the generic Type class.
-      module SpecificType
+      # This module provides common functionality for non-primitive types
+      # that do not require a name to be created.
+      module ComplexType
 
         def self.included(base)
           base.extend ClassMethods

--- a/lib/avro/builder/types/map_type.rb
+++ b/lib/avro/builder/types/map_type.rb
@@ -2,13 +2,13 @@ module Avro
   module Builder
     module Types
       class MapType < Type
-        include Avro::Builder::Types::SpecificType
+        include Avro::Builder::Types::ComplexType
         include Avro::Builder::Types::ConfigurableType
         include Avro::Builder::Types::TypeReferencer
 
         dsl_attribute :values do |value_type = nil|
           if value_type
-            @values = find_or_create_type(value_type)
+            @values = create_builtin_or_lookup_named_type(value_type)
           else
             @values
           end

--- a/lib/avro/builder/types/named_type.rb
+++ b/lib/avro/builder/types/named_type.rb
@@ -8,7 +8,7 @@ module Avro
       # This is an abstract class that represents a type that can be defined
       # with a name, outside a record.
       class NamedType < Type
-        include Avro::Builder::Types::SpecificType
+        include Avro::Builder::Types::ComplexType
         include Avro::Builder::Namespaceable
         include Avro::Builder::Types::ConfigurableType
 

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -43,7 +43,7 @@ module Avro
         # Adds fields from the record with the specified name to the current
         # record.
         def extends(name)
-          fields.merge!(builder.lookup(name).duplicated_fields)
+          fields.merge!(builder.lookup_named_type(name).duplicated_fields)
         end
 
         def to_h(reference_state = SchemaSerializerReferenceState.new)

--- a/lib/avro/builder/types/type_referencer.rb
+++ b/lib/avro/builder/types/type_referencer.rb
@@ -12,8 +12,12 @@ module Avro
           (!field.nil? && field.builder) || super
         end
 
-        def find_or_create_type(type_name)
-          create_type(type_name) || builder.lookup(type_name)
+        def create_builtin_or_lookup_named_type(type_name)
+          if builtin_type?(type_name)
+            create_builtin_type(type_name)
+          else
+            builder.lookup_named_type(type_name)
+          end
         end
       end
     end

--- a/lib/avro/builder/types/type_referencer.rb
+++ b/lib/avro/builder/types/type_referencer.rb
@@ -13,7 +13,7 @@ module Avro
         end
 
         def find_or_create_type(type_name)
-          builder.lookup(type_name, required: false) || create_type(type_name)
+          create_type(type_name) || builder.lookup(type_name)
         end
       end
     end

--- a/lib/avro/builder/types/union_type.rb
+++ b/lib/avro/builder/types/union_type.rb
@@ -2,13 +2,15 @@ module Avro
   module Builder
     module Types
       class UnionType < Type
-        include Avro::Builder::Types::SpecificType
+        include Avro::Builder::Types::ComplexType
         include Avro::Builder::Types::ConfigurableType
         include Avro::Builder::Types::TypeReferencer
 
+        NULL_TYPE = 'null'.freeze
+
         dsl_attribute :types do |*types|
           if !types.empty?
-            @types = types.flatten.map { |type| find_or_create_type(type) }
+            @types = types.flatten.map { |type| create_builtin_or_lookup_named_type(type) }
           else
             @types
           end
@@ -22,7 +24,7 @@ module Avro
         # serialized will be an array of types. If the array includes
         # :null then it is moved to the beginning of the array.
         def self.union_with_null(serialized)
-          serialized.reject { |type| type == :null }.unshift(:null)
+          serialized.reject { |type| type.to_s == NULL_TYPE }.unshift(:null)
         end
       end
     end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end

--- a/spec/avro/builder/file_handler_spec.rb
+++ b/spec/avro/builder/file_handler_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe Avro::Builder::FileHandler do
+  before do
+    Avro::Builder.add_load_path('spec/avro/dsl')
+  end
+
+  context "loading external references" do
+    subject do
+      Avro::Builder.build do
+        record :with_reference do
+          required :external, :external_type
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_reference,
+        fields: [
+          {
+            name: :external,
+            type: {
+              type: :fixed,
+              name: :external_type,
+              namespace: :test,
+              size: 2
+            }
+          }
+        ]
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "loading qualified references" do
+    subject do
+      Avro::Builder.build do
+        record :with_qualified_reference do
+          required :external, 'test.external_type'
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_qualified_reference,
+        fields: [
+          {
+            name: :external,
+            type: {
+              type: :fixed,
+              name: :external_type,
+              namespace: :test,
+              size: 2
+            }
+          }
+        ]
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "when a reference cannot be resolved" do
+    subject do
+      Avro::Builder.build do
+        record :with_missing do
+          required :ref, :does_not_exist
+        end
+      end
+    end
+    it "raises an error" do
+      expect { subject }.to raise_error(/File not found/)
+    end
+  end
+
+  context "when a reference is ambiguous" do
+    subject do
+      Avro::Builder.build do
+        record :with_ambiguous do
+          required :ref, :ambiguous
+        end
+      end
+    end
+    it "raises an error" do
+      expect { subject }.to raise_error(/Multiple matches:/)
+    end
+  end
+
+  context "a file with a name that ends with a builtin type" do
+    let(:file_path) { 'spec/avro/dsl/test/with_array.rb' }
+    subject { Avro::Builder.build(File.read(file_path)) }
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_array,
+        namespace: :test,
+        fields: [
+          { name: :array_of_ints, type: { type: :array, items: :int } }
+        ]
+      }
+    end
+
+    it "does not match a partial file name" do
+      # previously this triggered an infinite loop
+      expect(subject).to be_json_eql(expected.to_json)
+    end
+
+    it "does not attempt to load 'array' from a file" do
+      allow(Avro::Builder::DSL).to receive(:import).and_call_original
+      expect(subject).to be_json_eql(expected.to_json)
+      expect(Avro::Builder::DSL).not_to have_received(:import).with(:array)
+    end
+  end
+end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -210,6 +210,29 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "record with namespace as an option" do
+    subject do
+      described_class.build do
+        record :rec, namespace: 'com.example.foo' do
+          optional :id, :long
+          required :type, :string
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :rec,
+        namespace: 'com.example.foo',
+        fields: [
+          { name: :id, type: [:null, :long], default: nil },
+          { name: :type, type: :string }
+        ]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
   context "record with inline enum" do
     subject do
       described_class.build do

--- a/spec/avro/dsl/other/ambiguous.rb
+++ b/spec/avro/dsl/other/ambiguous.rb
@@ -1,0 +1,4 @@
+record :ambiguous do
+  namespace :other
+  required :i, :int
+end

--- a/spec/avro/dsl/test/ambiguous.rb
+++ b/spec/avro/dsl/test/ambiguous.rb
@@ -1,0 +1,4 @@
+record :ambiguous do
+  namespace :test
+  required :i, :int
+end

--- a/spec/avro/dsl/test/external_type.rb
+++ b/spec/avro/dsl/test/external_type.rb
@@ -1,0 +1,2 @@
+namespace :test
+fixed :external_type, size: 2

--- a/spec/avro/dsl/test/with_array.rb
+++ b/spec/avro/dsl/test/with_array.rb
@@ -1,0 +1,3 @@
+record :with_array, namespace: :test do
+  required :array_of_ints, :array, items: :int
+end

--- a/spec/avro/original_spec.rb
+++ b/spec/avro/original_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe Avro::Builder do
-  it 'has a version number' do
-    expect(Avro::Builder::VERSION).not_to be nil
-  end
-end


### PR DESCRIPTION
From the changelog:
- Fix a bug that allowed the partial matching of filenames.
- Fix a bug that prevented namespace from being specified as an option on
  records.
- Fix a bug that prevented loading references qualified by namespace.
- Do not attempt to import schema files for builtin types.

Prime: @jturkel 