### PR TITLE
Make definition lookup private

### DIFF
--- a/lib/avro/builder/definition_proxy.rb
+++ b/lib/avro/builder/definition_proxy.rb
@@ -1,0 +1,32 @@
+module Avro
+  module Builder
+
+    # This class is used to proxy access to previously defined schema objects
+    # preventing direct access via the DSL.
+    class DefinitionProxy
+
+      def initialize(builder, schema_objects)
+        @builder = builder
+        @schema_objects = schema_objects
+      end
+
+      # Lookup an Avro schema object by name, possibly fully qualified by namespace.
+      def lookup_named_type(key)
+        key_str = key.to_s
+        object = schema_objects[key_str]
+
+        unless object
+          builder.import(key)
+          object = schema_objects[key_str]
+        end
+
+        raise "Schema object #{key} not found" unless object
+        object
+      end
+
+      private
+
+      attr_reader :schema_objects, :builder
+    end
+  end
+end

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -12,8 +12,6 @@ module Avro
 
       INTERNAL_ATTRIBUTES = Set.new(%i(optional_field)).freeze
 
-      attr_accessor :type, :optional_field, :builder, :record
-
       # These attributes may be set as options or via a block in the DSL
       dsl_attributes :doc, :aliases, :default, :order
 
@@ -33,6 +31,7 @@ module Avro
         @type = if builtin_type?(type_name)
                   create_and_configure_builtin_type(type_name,
                                                     field: self,
+                                                    builder: builder,
                                                     internal: internal,
                                                     options: options)
                 else
@@ -80,6 +79,8 @@ module Avro
       end
 
       private
+
+      attr_accessor :type, :optional_field, :builder, :record
 
       # Optional fields must be serialized as a union -- an array of types.
       def serialized_type(reference_state)

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -10,13 +10,13 @@ module Avro
       private
 
       # Return a new Type instance
-      def create_builtin_type(type_name)
+      def create_builtin_type(type_name, field:, builder:)
         name = type_name.to_s.downcase
         case
         when Avro::Schema::PRIMITIVE_TYPES.include?(name)
-          Avro::Builder::Types::Type.new(name)
+          Avro::Builder::Types::Type.new(name, field: field, builder: builder)
         when COMPLEX_TYPES.include?(name)
-          Avro::Builder::Types.const_get("#{name.capitalize}Type").new
+          Avro::Builder::Types.const_get("#{name.capitalize}Type").new(field: field, builder: builder)
         else
           raise "Invalid builtin type: #{type_name}"
         end
@@ -30,9 +30,7 @@ module Avro
                                             internal: {},
                                             options: {},
                                             &block)
-        create_builtin_type(type_name).tap do |type|
-          type.field = field
-          type.builder = builder
+        create_builtin_type(type_name, field: field, builder: builder).tap do |type|
           type.configure_options(internal.merge(options))
           type.instance_eval(&block) if block_given?
         end

--- a/lib/avro/builder/types/complex_type.rb
+++ b/lib/avro/builder/types/complex_type.rb
@@ -11,11 +11,8 @@ module Avro
         end
 
         # Override initialize so that type name is not required
-        def initialize
-        end
-
-        def type_name
-          self.class.type_name
+        def initialize(builder:, field: nil)
+          super(self.class.type_name, builder: builder, field: field)
         end
 
         module ClassMethods

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -7,11 +7,14 @@ module Avro
 
         dsl_attributes :doc
 
-        def initialize(name = nil, options = {})
+        def initialize(name = nil, options: {}, builder:, field: nil, &block)
+          @type_name = :record
           @name = name
-          options.each do |key, value|
-            send(key, value)
-          end
+          @builder = builder
+          @field = field
+
+          configure_options(options)
+          instance_eval(&block) if block_given?
         end
 
         # Add a required field to the record
@@ -78,12 +81,6 @@ module Avro
 
         def fields
           @fields ||= {}
-        end
-
-        # A record may be defined as a top-level schema or as the
-        # type for a field.
-        def builder
-          super || field.builder
         end
       end
     end

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -8,10 +8,11 @@ module Avro
         include Avro::Builder::DslAttributes
 
         attr_reader :type_name
-        attr_accessor :field, :builder
 
-        def initialize(type_name)
+        def initialize(type_name, builder:, field: nil)
           @type_name = type_name
+          @builder = builder
+          @field = field
         end
 
         def serialize(_reference_state)
@@ -30,6 +31,10 @@ module Avro
         def self.union_with_null(serialized)
           [:null, serialized]
         end
+
+        private
+
+        attr_accessor :field, :builder
       end
     end
   end

--- a/lib/avro/builder/types/type_referencer.rb
+++ b/lib/avro/builder/types/type_referencer.rb
@@ -8,13 +8,9 @@ module Avro
       module TypeReferencer
         include Avro::Builder::TypeFactory
 
-        def builder
-          (!field.nil? && field.builder) || super
-        end
-
         def create_builtin_or_lookup_named_type(type_name)
           if builtin_type?(type_name)
-            create_builtin_type(type_name)
+            create_builtin_type(type_name, field: field, builder: builder)
           else
             builder.lookup_named_type(type_name)
           end


### PR DESCRIPTION
This change is against https://github.com/salsify/avro-builder/pull/11. It is an attempt to address the concern raised there that the `lookup` method was exposed in the DSL.

A proxy object is introduced that limits access to lookup previous definitions.

As part of the implementation other internal state was moved to private.

FYI @jturkel 