### PR TITLE
Validate require DSL attributes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avro-builder changelog
 
+## v0.4.0
+- Add validation for required DSL attributes that are not specified.
+- Allow name to be configured via a block for top-level record, enum, and fixed
+  types.
+
 ## v0.3.2
 - Fix a bug that allowed the partial matching of filenames.
 - Fix a bug that prevented namespace from being specified as an option on

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This DSL was created because:
 * Only Avro Schemas, not Protocols are supported.
 * See [Issues](https://github.com/salsify/avro-builder/issues) for functionality
   that has yet to be implemented.
-* This is alpha quality code. There may be breaking changes until version 1.0 is
+* This is beta quality code. There may be breaking changes until version 1.0 is
   released.
 
 ## Installation

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -26,7 +26,7 @@ module Avro
 
       # Define an Avro schema record
       def record(name, options = {}, &block)
-        add_schema_object(build_record(name, options, &block))
+        create_named_type(name, :record, options, &block)
       end
 
       # Imports from the file with specified name fragment.
@@ -106,14 +106,6 @@ module Avro
                                           &block).tap do |type|
           add_schema_object(type)
         end
-      end
-
-      def build_record(name, options, &block)
-        Avro::Builder::Types::RecordType
-          .new(name, { namespace: namespace }.merge(options)).tap do |record|
-            record.builder = builder
-            record.instance_eval(&block)
-          end
       end
 
       def eval_file(name)

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -1,4 +1,5 @@
 require 'avro'
+require 'avro/builder/errors'
 require 'avro/builder/dsl_attributes'
 require 'avro/builder/namespaceable'
 require 'avro/builder/type_factory'
@@ -25,7 +26,7 @@ module Avro
       end
 
       # Define an Avro schema record
-      def record(name, options = {}, &block)
+      def record(name = nil, options = {}, &block)
         create_named_type(name, :record, options, &block)
       end
 
@@ -38,11 +39,11 @@ module Avro
 
       ## DSL methods for Types
 
-      def enum(name, *symbols, **options, &block)
+      def enum(name = nil, *symbols, **options, &block)
         create_named_type(name, :enum, { symbols: symbols }.merge(options), &block)
       end
 
-      def fixed(name, size = nil, options = {}, &block)
+      def fixed(name = nil, size = nil, options = {}, &block)
         size_option = size.is_a?(Hash) ? size : { size: size }
         create_named_type(name, :fixed, size_option.merge(options), &block)
       end
@@ -104,6 +105,7 @@ module Avro
                                           internal: { name: name, namespace: namespace },
                                           options: options,
                                           &block).tap do |type|
+          type.validate!
           add_schema_object(type)
         end
       end

--- a/lib/avro/builder/errors.rb
+++ b/lib/avro/builder/errors.rb
@@ -1,0 +1,15 @@
+module Avro
+  module Builder
+
+    class RequiredAttributeError < StandardError
+      def initialize(type:, attribute:, field: nil, name: nil)
+        location = if field
+                     "field '#{field}' of "
+                   elsif name
+                     "'#{name}' of "
+                   end
+        super("attribute :#{attribute} missing for #{location}type :#{type}")
+      end
+    end
+  end
+end

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -41,6 +41,7 @@ module Avro
 
         # DSL calls must be evaluated after the type has been constructed
         instance_eval(&block) if block_given?
+        @type.validate!
       end
 
       ## Delegate additional DSL calls to the type

--- a/lib/avro/builder/types/array_type.rb
+++ b/lib/avro/builder/types/array_type.rb
@@ -14,6 +14,10 @@ module Avro
           end
         end
 
+        def validate!
+          missing!(:items)
+        end
+
         def serialize(referenced_state)
           {
             type: type_name,

--- a/lib/avro/builder/types/array_type.rb
+++ b/lib/avro/builder/types/array_type.rb
@@ -15,7 +15,7 @@ module Avro
         end
 
         def validate!
-          missing!(:items)
+          validate_required_attribute!(:items)
         end
 
         def serialize(referenced_state)

--- a/lib/avro/builder/types/enum_type.rb
+++ b/lib/avro/builder/types/enum_type.rb
@@ -22,6 +22,11 @@ module Avro
           super(reference_state, overrides: serialized_attributes)
         end
 
+        def validate!
+          super
+          missing!(:symbols)
+        end
+
         private
 
         def serialized_attributes

--- a/lib/avro/builder/types/enum_type.rb
+++ b/lib/avro/builder/types/enum_type.rb
@@ -24,7 +24,7 @@ module Avro
 
         def validate!
           super
-          missing!(:symbols)
+          validate_required_attribute!(:symbols)
         end
 
         private

--- a/lib/avro/builder/types/fixed_type.rb
+++ b/lib/avro/builder/types/fixed_type.rb
@@ -13,6 +13,11 @@ module Avro
           super(reference_state, overrides: serialized_attributes)
         end
 
+        def validate!
+          super
+          missing!(:size)
+        end
+
         private
 
         def serialized_attributes

--- a/lib/avro/builder/types/fixed_type.rb
+++ b/lib/avro/builder/types/fixed_type.rb
@@ -15,7 +15,7 @@ module Avro
 
         def validate!
           super
-          missing!(:size)
+          validate_required_attribute!(:size)
         end
 
         private

--- a/lib/avro/builder/types/map_type.rb
+++ b/lib/avro/builder/types/map_type.rb
@@ -20,6 +20,10 @@ module Avro
             values: values.serialize(referenced_state)
           }
         end
+
+        def validate!
+          missing!(:values)
+        end
       end
     end
   end

--- a/lib/avro/builder/types/map_type.rb
+++ b/lib/avro/builder/types/map_type.rb
@@ -22,7 +22,7 @@ module Avro
         end
 
         def validate!
-          missing!(:values)
+          validate_required_attribute!(:values)
         end
       end
     end

--- a/lib/avro/builder/types/named_type.rb
+++ b/lib/avro/builder/types/named_type.rb
@@ -22,6 +22,10 @@ module Avro
           end
         end
 
+        def validate!
+          required_attribute_error!(:name) if field.nil? && @name.nil?
+        end
+
         # Named types that do not have an explicit name are assigned
         # a named based on the field and its nesting.
         def name_fragment

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -45,7 +45,7 @@ module Avro
                                            name: @name)
         end
 
-        def missing!(attribute_name)
+        def validate_required_attribute!(attribute_name)
           value = public_send(attribute_name)
           if value.nil? || value.respond_to?(:empty?) && value.empty?
             required_attribute_error!(attribute_name)

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -30,6 +30,27 @@ module Avro
         def self.union_with_null(serialized)
           [:null, serialized]
         end
+
+        # Subclasses should override this method to check for the presence
+        # of required DSL attributes.
+        def validate!
+        end
+
+        private
+
+        def required_attribute_error!(attribute_name)
+          raise RequiredAttributeError.new(type: type_name,
+                                           attribute: attribute_name,
+                                           field: field && field.name,
+                                           name: @name)
+        end
+
+        def missing!(attribute_name)
+          value = public_send(attribute_name)
+          if value.nil? || value.respond_to?(:empty?) && value.empty?
+            required_attribute_error!(attribute_name)
+          end
+        end
       end
     end
   end

--- a/lib/avro/builder/types/union_type.rb
+++ b/lib/avro/builder/types/union_type.rb
@@ -26,6 +26,10 @@ module Avro
         def self.union_with_null(serialized)
           serialized.reject { |type| type.to_s == NULL_TYPE }.unshift(:null)
         end
+
+        def validate!
+          missing!(:types)
+        end
       end
     end
   end

--- a/lib/avro/builder/types/union_type.rb
+++ b/lib/avro/builder/types/union_type.rb
@@ -28,7 +28,7 @@ module Avro
         end
 
         def validate!
-          missing!(:types)
+          validate_required_attribute!(:types)
         end
       end
     end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = "0.3.2"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -97,6 +97,55 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "enum with block" do
+    subject do
+      described_class.build do
+        enum do
+          name :enum3
+          symbols :A, :B
+        end
+      end
+    end
+    let(:expected) do
+      {
+        name: :enum3,
+        type: :enum,
+        symbols: [:A, :B]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "enum without symbols" do
+    subject do
+      described_class.build_schema do
+        enum :broken_enum
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       "attribute :symbols missing for 'broken_enum' of type :enum")
+    end
+  end
+
+  context "enum without name" do
+    subject do
+      described_class.build_schema do
+        enum do
+          symbols %(A B)
+        end
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       'attribute :name missing for type :enum')
+    end
+  end
+
   context "fixed type" do
     subject do
       described_class.build do
@@ -149,6 +198,55 @@ describe Avro::Builder do
       }
     end
     it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "fixed with block" do
+    subject do
+      described_class.build do
+        fixed do
+          name :eight
+          size 9
+        end
+      end
+    end
+    let(:expected) do
+      {
+        name: :eight,
+        type: :fixed,
+        size: 9
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "fixed without size" do
+    subject do
+      described_class.build do
+        fixed :broken_fixed
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       "attribute :size missing for 'broken_fixed' of type :fixed")
+    end
+  end
+
+  context "fixed without name" do
+    subject do
+      described_class.build do
+        fixed do
+          size 2
+        end
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       'attribute :name missing for type :fixed')
+    end
   end
 
   context "record" do
@@ -450,6 +548,22 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "record without name" do
+    subject do
+      described_class.build do
+        record do
+          required :i, :int
+        end
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       'attribute :name missing for type :record')
+    end
+  end
+
   context "union" do
     subject do
       described_class.build do
@@ -567,6 +681,22 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "union without types" do
+    subject do
+      described_class.build do
+        record :broken_union do
+          required :u, :union
+        end
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       "attribute :types missing for field 'u' of type :union")
+    end
+  end
+
   context "map" do
     subject do
       described_class.build do
@@ -609,6 +739,22 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "map without values type" do
+    subject do
+      described_class.build do
+        record :broken_map do
+          required :m, :map
+        end
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       "attribute :values missing for field 'm' of type :map")
+    end
+  end
+
   context "array" do
     subject do
       described_class.build do
@@ -649,6 +795,22 @@ describe Avro::Builder do
       }
     end
     it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "array without items type" do
+    subject do
+      described_class.build do
+        record :broken_array do
+          required :a, :array
+        end
+      end
+    end
+
+    it "is invalid" do
+      expect { subject }.
+        to raise_error(Avro::Builder::RequiredAttributeError,
+                       "attribute :items missing for field 'a' of type :array")
+    end
   end
 
   context "record with extends" do


### PR DESCRIPTION
This change addresses https://github.com/salsify/avro-builder/issues/15. Since most attributes can be specified as arguments or via a block, a `validate!` method is added to types and called after they are configured.

Other changes here:
- The `Avro::Builder::DSL#build_record` method was unnecessary and has been removed.
- `name` is now an optional argument for record, enum and fixed types at the top-level. This improves
  the error reporting and allows `name` to be specified via a supplied block.

Prime: @jturkel 