### PR TITLE
Support references to named types defined inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-builder changelog
 
+## v0.5.0
+- Support references to named types that are defined inline.
+- Raise an error for duplicate definitions with the same name.
+
 ## v0.4.0
 - Add validation for required DSL attributes that are not specified.
 - Allow name to be configured via a block for top-level record, enum, and fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 - Support references to named types that are defined inline.
-- Raise an error for duplicate definitions with the same name.
+- Raise an error for duplicate definitions with the same fullname.
 
 ## v0.4.0
 - Add validation for required DSL attributes that are not specified.

--- a/lib/avro/builder/definition_cache.rb
+++ b/lib/avro/builder/definition_cache.rb
@@ -10,13 +10,12 @@ module Avro
       end
 
       def add_schema_object(object)
-        store_if_new(object.fullname, object) if object.namespace
-        store_if_new(object.name.to_s, object)
+        store_if_new(object.fullname, object)
       end
 
       # Lookup an Avro schema object by name, possibly fully qualified by namespace.
-      def lookup_named_type(key)
-        key_str = key.to_s
+      def lookup_named_type(key, namespace = nil)
+        key_str = Avro::Name.make_fullname(key.to_s, namespace)
         object = schema_objects[key_str]
 
         unless object

--- a/lib/avro/builder/definition_cache.rb
+++ b/lib/avro/builder/definition_cache.rb
@@ -1,0 +1,41 @@
+module Avro
+  module Builder
+
+    # This class is used to cache previously defined schema objects
+    # preventing direct access via the DSL.
+    class DefinitionCache
+      def initialize(builder)
+        @builder = builder
+        @schema_objects = {}
+      end
+
+      def add_schema_object(object)
+        store_if_new(object.fullname, object) if object.namespace
+        store_if_new(object.name.to_s, object)
+      end
+
+      # Lookup an Avro schema object by name, possibly fully qualified by namespace.
+      def lookup_named_type(key)
+        key_str = key.to_s
+        object = schema_objects[key_str]
+
+        unless object
+          builder.import(key)
+          object = schema_objects[key_str]
+        end
+
+        raise "Schema object #{key} not found" unless object
+        object
+      end
+
+      private
+
+      def store_if_new(key, object)
+        raise DuplicateDefinitionError.new(key, object, schema_objects[key]) if schema_objects.key?(key)
+        schema_objects.store(key, object)
+      end
+
+      attr_reader :schema_objects, :builder
+    end
+  end
+end

--- a/lib/avro/builder/definition_cache.rb
+++ b/lib/avro/builder/definition_cache.rb
@@ -7,34 +7,58 @@ module Avro
       def initialize(builder)
         @builder = builder
         @schema_objects = {}
+        @schema_names = Set.new
       end
 
+      # Cache and schema object by name (for convenience) and fullname.
+      # The schema object is only available by name if the unqualified name is unique.
       def add_schema_object(object)
-        store_if_new(object.fullname, object)
+        store_by_name(object) if object.namespace
+        store_by_fullname(object)
       end
 
       # Lookup an Avro schema object by name, possibly fully qualified by namespace.
       def lookup_named_type(key, namespace = nil)
-        key_str = Avro::Name.make_fullname(key.to_s, namespace)
+        key_str = Avro::Name.make_fullname(key.to_s, namespace && namespace.to_s)
         object = schema_objects[key_str]
 
-        unless object
-          builder.import(key)
-          object = schema_objects[key_str]
+        unless object || schema_names.include?(key.to_s)
+          object = builder.import(key)
         end
 
-        raise "Schema object #{key} not found" unless object
+        raise DefinitionNotFoundError.new(key) unless object
         object
+      rescue DefinitionNotFoundError
+        if namespace
+          lookup_named_type(key, nil)
+        else
+          raise
+        end
       end
 
       private
 
-      def store_if_new(key, object)
+      # Schemas are stored by name, provided that the name is unique.
+      # If the unqualified name is ambiguous then it is removed from the cache.
+      # A set of unqualified names is kept to avoid reloading files for
+      # ambiguous references.
+      def store_by_name(object)
+        key = object.name.to_s
+        schema_names.add(key)
+        if schema_objects.key?(key)
+          schema_objects.delete(key)
+        else
+          schema_objects.store(key, object)
+        end
+      end
+
+      def store_by_fullname(object)
+        key = object.fullname
         raise DuplicateDefinitionError.new(key, object, schema_objects[key]) if schema_objects.key?(key)
         schema_objects.store(key, object)
       end
 
-      attr_reader :schema_objects, :builder
+      attr_reader :schema_objects, :schema_names, :builder
     end
   end
 end

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -34,8 +34,9 @@ module Avro
       # Imports from the file with specified name fragment.
       def import(name)
         previous_namespace = namespace
-        eval_file(name)
+        result = eval_file(name)
         namespace(previous_namespace)
+        result
       end
 
       ## DSL methods for Types

--- a/lib/avro/builder/errors.rb
+++ b/lib/avro/builder/errors.rb
@@ -25,5 +25,19 @@ module Avro
         object.to_h(SchemaSerializerReferenceState.new).to_json
       end
     end
+
+    class DefinitionNotFoundError < StandardError
+      def initialize(name)
+        super("definition not found for '#{name.to_s}'.#{suggest_namespace(name)}")
+      end
+
+      private
+
+      def suggest_namespace(name)
+        unless name.to_s.index('.')
+          ' Try specifying the full namespace.'
+        end
+      end
+    end
   end
 end

--- a/lib/avro/builder/errors.rb
+++ b/lib/avro/builder/errors.rb
@@ -11,5 +11,19 @@ module Avro
         super("attribute :#{attribute} missing for #{location}type :#{type}")
       end
     end
+
+    class DuplicateDefinitionError < StandardError
+      def initialize(key, object, existing_object)
+        super("definition for #{key.inspect} already exists\n"\
+              "existing definition:\n#{to_json(existing_object)}\n"\
+              "new definition:\n#{to_json(object)})")
+      end
+
+      private
+
+      def to_json(object)
+        object.to_h(SchemaSerializerReferenceState.new).to_json
+      end
+    end
   end
 end

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -7,7 +7,6 @@ module Avro
     # A field must be initialized with a type.
     class Field
       include Avro::Builder::DslAttributes
-      include Avro::Builder::Namespaceable
       include Avro::Builder::TypeFactory
 
       INTERNAL_ATTRIBUTES = Set.new(%i(optional_field)).freeze
@@ -36,7 +35,7 @@ module Avro
                                                     options: options)
                 else
                   named_type = true
-                  cache.lookup_named_type(type_name)
+                  cache.lookup_named_type(type_name, namespace)
                 end
 
         # DSL calls must be evaluated after the type has been constructed
@@ -57,6 +56,16 @@ module Avro
 
       def name_fragment
         record.name_fragment
+      end
+
+      # Delegate setting namespace explicitly via DSL to type
+      # and return the namespace value from the enclosing record.
+      def namespace(value = nil)
+        if value
+          type.namespace(value)
+        else
+          record.namespace
+        end
       end
 
       # Delegate setting name explicitly via DSL to type

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -10,13 +10,13 @@ module Avro
       private
 
       # Return a new Type instance
-      def create_builtin_type(type_name)
+      def create_builtin_type(type_name, field:, cache:)
         name = type_name.to_s.downcase
         case
         when Avro::Schema::PRIMITIVE_TYPES.include?(name)
-          Avro::Builder::Types::Type.new(name)
+          Avro::Builder::Types::Type.new(name, field: field, cache: cache)
         when COMPLEX_TYPES.include?(name)
-          Avro::Builder::Types.const_get("#{name.capitalize}Type").new
+          Avro::Builder::Types.const_get("#{name.capitalize}Type").new(field: field, cache: cache)
         else
           raise "Invalid builtin type: #{type_name}"
         end
@@ -26,13 +26,11 @@ module Avro
       # and setting attributes via the DSL
       def create_and_configure_builtin_type(type_name,
                                             field: nil,
-                                            builder: nil,
+                                            cache: nil,
                                             internal: {},
                                             options: {},
                                             &block)
-        create_builtin_type(type_name).tap do |type|
-          type.field = field
-          type.builder = builder
+        create_builtin_type(type_name, field: field, cache: cache).tap do |type|
           type.configure_options(internal.merge(options))
           type.instance_eval(&block) if block_given?
         end

--- a/lib/avro/builder/types/complex_type.rb
+++ b/lib/avro/builder/types/complex_type.rb
@@ -11,11 +11,8 @@ module Avro
         end
 
         # Override initialize so that type name is not required
-        def initialize
-        end
-
-        def type_name
-          self.class.type_name
+        def initialize(cache:, field: nil)
+          super(self.class.type_name, cache: cache, field: field)
         end
 
         module ClassMethods

--- a/lib/avro/builder/types/complex_type.rb
+++ b/lib/avro/builder/types/complex_type.rb
@@ -15,6 +15,10 @@ module Avro
           super(self.class.type_name, cache: cache, field: field)
         end
 
+        def namespace
+          field.namespace
+        end
+
         module ClassMethods
 
           # Infer type_name based on class

--- a/lib/avro/builder/types/named_type.rb
+++ b/lib/avro/builder/types/named_type.rb
@@ -26,6 +26,10 @@ module Avro
           required_attribute_error!(:name) if field.nil? && @name.nil?
         end
 
+        def cache!
+          cache.add_schema_object(self)
+        end
+
         # Named types that do not have an explicit name are assigned
         # a named based on the field and its nesting.
         def name_fragment

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -46,7 +46,7 @@ module Avro
         # Adds fields from the record with the specified name to the current
         # record.
         def extends(name)
-          fields.merge!(cache.lookup_named_type(name).duplicated_fields)
+          fields.merge!(cache.lookup_named_type(name, namespace).duplicated_fields)
         end
 
         def to_h(reference_state = SchemaSerializerReferenceState.new)

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -8,10 +8,11 @@ module Avro
         include Avro::Builder::DslAttributes
 
         attr_reader :type_name
-        attr_accessor :field, :builder
 
-        def initialize(type_name)
+        def initialize(type_name, cache:, field: nil)
           @type_name = type_name
+          @cache = cache
+          @field = field
         end
 
         def serialize(_reference_state)
@@ -36,6 +37,11 @@ module Avro
         def validate!
         end
 
+        # Subclasses should override this method if the type definition should
+        # be cached for reuse.
+        def cache!
+        end
+
         private
 
         def required_attribute_error!(attribute_name)
@@ -51,6 +57,10 @@ module Avro
             required_attribute_error!(attribute_name)
           end
         end
+
+        private
+
+        attr_accessor :field, :cache
       end
     end
   end

--- a/lib/avro/builder/types/type_referencer.rb
+++ b/lib/avro/builder/types/type_referencer.rb
@@ -8,15 +8,11 @@ module Avro
       module TypeReferencer
         include Avro::Builder::TypeFactory
 
-        def builder
-          (!field.nil? && field.builder) || super
-        end
-
         def create_builtin_or_lookup_named_type(type_name)
           if builtin_type?(type_name)
-            create_builtin_type(type_name)
+            create_builtin_type(type_name, field: field, cache: cache)
           else
-            builder.lookup_named_type(type_name)
+            cache.lookup_named_type(type_name)
           end
         end
       end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end

--- a/spec/avro/builder/file_handler_spec.rb
+++ b/spec/avro/builder/file_handler_spec.rb
@@ -9,7 +9,7 @@ describe Avro::Builder::FileHandler do
     subject do
       Avro::Builder.build do
         record :with_reference do
-          required :external, :external_type
+          required :external, 'test.external_type'
         end
       end
     end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1102,6 +1102,7 @@ describe Avro::Builder do
       described_class.build do
         fixed :a_fix, size: 5, namespace: :test
         fixed :a_fix, size: 6, namespace: :other
+        fixed :a_fix, size: 7, namespace: :third
 
         record :with_a_fix do
           required :fix, :a_fix

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -521,7 +521,7 @@ describe Avro::Builder do
 
         namespace 'com.example.two'
         record :uses_id do
-          required :pkey, :id
+          required :pkey, 'com.example.one.id'
         end
       end
     end
@@ -921,7 +921,7 @@ describe Avro::Builder do
 
         record :top_rec do
           namespace 'com.example.B'
-          required :sub, :sub_rec
+          required :sub, 'com.example.A.sub_rec'
         end
       end
     end


### PR DESCRIPTION
This change adds support for references to named types that are defined inline:

```ruby
record :with_magic do
  required :magic, :fixed, name: :Magic, size: 4
  required :more_magic, :Magic
end
```

In the course of implementing of this change, the DSL interface was refactored to hide the lookup of previously defined types.

The handling of namespaces has also been overhauled. Now by default unqualified references are first resolved based on the namespace where the reference is made. For convenience, unqualified references are still supported provided that they are unambiguous.

Prime: @jturkel 