### PR TITLE
DSL Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # avro-builder changelog
 
+## v0.6.0
+- Support recursive definitions.
+- Coerce aliases to be represented as an array.
+- Only allow name and namespace to be set via options, not via a block, for
+  record, enum, and fixed types.
+- Allow aliases to be set on a field and a type defined inline.
+
 ## v0.5.0
 - Support references to named types that are defined inline.
 - Raise an error for duplicate definitions with the same fullname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # avro-builder changelog
 
-## v0.6.0
+## v0.6.0 (unreleased)
 - Support recursive definitions.
 - Coerce aliases to be represented as an array.
 - Only allow name and namespace to be set via options, not via a block, for
   record, enum, and fixed types.
-- Allow aliases to be set on a field and a type defined inline.
+- Allow `doc` and `aliases` to be set on both a field and a type defined inline
+  for the field. To set these attributes on the inline type `type_doc` and 
+  `type_aliases` must be used in the DSL.
 
 ## v0.5.0
 - Support references to named types that are defined inline.

--- a/lib/avro/builder/aliasable.rb
+++ b/lib/avro/builder/aliasable.rb
@@ -1,0 +1,20 @@
+require 'avro/builder/dsl_attributes'
+
+module Avro
+  module Builder
+
+    # This is a shared concern for objects that support aliases via the DSL.
+    module Aliasable
+      def self.included(base)
+        base.dsl_attribute :aliases do |*names|
+          if !names.empty?
+            @aliases = names.flatten
+          else
+            @aliases
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/avro/builder/aliasable.rb
+++ b/lib/avro/builder/aliasable.rb
@@ -6,7 +6,7 @@ module Avro
     # This is a shared concern for objects that support aliases via the DSL.
     module Aliasable
       def self.included(base)
-        base.dsl_attribute :aliases do |*names|
+        base.dsl_attribute(:aliases) do |*names|
           if !names.empty?
             @aliases = names.flatten
           else

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -84,7 +84,7 @@ module Avro
                                           options: options,
                                           &block).tap do |type|
           type.validate!
-          @last_object = cache.add_schema_object(type)
+          @last_object = type
         end
       end
 

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -1,5 +1,6 @@
 require 'avro'
 require 'avro/builder/errors'
+require 'avro/builder/dsl_options'
 require 'avro/builder/dsl_attributes'
 require 'avro/builder/namespaceable'
 require 'avro/builder/definition_cache'
@@ -14,6 +15,7 @@ module Avro
     # This class is used to construct Avro schemas (not protocols) using a ruby
     # DSL
     class DSL
+      include Avro::Builder::DslOptions
       include Avro::Builder::DslAttributes
       include Avro::Builder::FileHandler
       include Avro::Builder::TypeFactory

--- a/lib/avro/builder/dsl_attributes.rb
+++ b/lib/avro/builder/dsl_attributes.rb
@@ -19,10 +19,6 @@ module Avro
         base.extend ClassMethods
       end
 
-      def dsl_option?(name)
-        self.class.dsl_option_names.include?(name.to_sym)
-      end
-
       def dsl_attribute?(name)
         self.class.dsl_attribute_names.include?(name.to_sym)
       end
@@ -48,16 +44,6 @@ module Avro
           end
         end
 
-        # A DSL option is only settable as an option, not as method in a block.
-        def dsl_option(name, &block)
-          dsl_option_names << name
-          if block_given?
-            define_method(name, &block)
-          else
-            define_accessor(name)
-          end
-        end
-
         def dsl_attribute_alias(new_name, old_name)
           alias_method(new_name, old_name)
           add_attribute_name(new_name)
@@ -72,27 +58,11 @@ module Avro
             end
         end
 
-        def dsl_option_names
-          @dsl_option_names ||=
-            if superclass.respond_to?(:dsl_option_names)
-              superclass.dsl_option_names.dup
-            else
-              Set.new
-            end
-        end
-
         private
 
         def add_attribute_name(name)
           dsl_attribute_names << name
-          dsl_option_names << name
-        end
-
-        def define_accessor(name)
-          ivar = :"@#{name}"
-          define_method(name) do |value = nil|
-            value ? instance_variable_set(ivar, value) : instance_variable_get(ivar)
-          end
+          add_option_name(name)
         end
       end
     end

--- a/lib/avro/builder/dsl_attributes.rb
+++ b/lib/avro/builder/dsl_attributes.rb
@@ -70,7 +70,7 @@ module Avro
         def define_accessor(name)
           ivar = :"@#{name}"
           define_method(name) do |value = nil|
-            value ? instance_variable_set(ivar, value) : instance_variable_get(ivar)
+            value.nil? ? instance_variable_get(ivar) : instance_variable_set(ivar, value)
           end
           alias_writer(name)
         end

--- a/lib/avro/builder/dsl_attributes.rb
+++ b/lib/avro/builder/dsl_attributes.rb
@@ -2,14 +2,14 @@ module Avro
   module Builder
 
     # This module provides methods for defining attributes that can be
-    # set  via the DSL on various objects.
+    # set via the DSL on various objects.
     #
     # The methods generated for DSL attributes are combined getter/setters
     # of the form:
     #
     #   attribute(value = nil)
     #
-    # When value is provided the attribute is set, and when it is nil the
+    # When a value is provided the attribute is set, and when it is nil the
     # current value is returned.
     #
     # When a DSL attribute is defined, the class also keeps track of the
@@ -19,18 +19,21 @@ module Avro
         base.extend ClassMethods
       end
 
+      def dsl_option?(name)
+        self.class.dsl_option_names.include?(name.to_sym)
+      end
+
       def dsl_attribute?(name)
         self.class.dsl_attribute_names.include?(name.to_sym)
       end
 
       module ClassMethods
         def dsl_attributes(*names)
+          raise 'a block can only be specified with dsl_attribute' if block_given?
+
           names.each do |name|
-            dsl_attribute_names << name
-            ivar = :"@#{name}"
-            define_method(name) do |value = nil|
-              value ? instance_variable_set(ivar, value) : instance_variable_get(ivar)
-            end
+            add_attribute_name(name)
+            define_accessor(name)
           end
         end
 
@@ -38,11 +41,26 @@ module Avro
         # combined getter/setter method for the DSL attribute.
         def dsl_attribute(name, &block)
           if block_given?
-            dsl_attribute_names << name
+            add_attribute_name(name)
             define_method(name, &block)
           else
             dsl_attributes(name)
           end
+        end
+
+        # A DSL option is only settable as an option, not as method in a block.
+        def dsl_option(name, &block)
+          dsl_option_names << name
+          if block_given?
+            define_method(name, &block)
+          else
+            define_accessor(name)
+          end
+        end
+
+        def dsl_attribute_alias(new_name, old_name)
+          alias_method(new_name, old_name)
+          add_attribute_name(new_name)
         end
 
         def dsl_attribute_names
@@ -52,6 +70,29 @@ module Avro
             else
               Set.new
             end
+        end
+
+        def dsl_option_names
+          @dsl_option_names ||=
+            if superclass.respond_to?(:dsl_option_names)
+              superclass.dsl_option_names.dup
+            else
+              Set.new
+            end
+        end
+
+        private
+
+        def add_attribute_name(name)
+          dsl_attribute_names << name
+          dsl_option_names << name
+        end
+
+        def define_accessor(name)
+          ivar = :"@#{name}"
+          define_method(name) do |value = nil|
+            value ? instance_variable_set(ivar, value) : instance_variable_get(ivar)
+          end
         end
       end
     end

--- a/lib/avro/builder/dsl_options.rb
+++ b/lib/avro/builder/dsl_options.rb
@@ -1,0 +1,64 @@
+module Avro
+  module Builder
+
+    # This module provides methods for defining options that can be
+    # set via the DSL on various objects.
+    #
+    # These attributes can only be set as options, and not as method in
+    # DSL block.
+    #
+    # The methods generated for DSL options are combined getter/setters
+    # of the form:
+    #
+    #   option(value = nil)
+    #
+    # When a value is provided the option is set, and when it is nil the
+    # current value is returned.
+    #
+    # When a DSL option is defined, the class also keeps track of the
+    # option names.
+    module DslOptions
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      def dsl_option?(name)
+        self.class.dsl_option_names.include?(name.to_sym)
+      end
+
+      module ClassMethods
+        # A DSL option is only settable as an option, not as method in a block.
+        def dsl_option(name, &block)
+          add_option_name(name)
+          if block_given?
+            define_method(name, &block)
+          else
+            define_accessor(name)
+          end
+        end
+
+        def dsl_option_names
+          @dsl_option_names ||=
+            if superclass.respond_to?(:dsl_option_names)
+              superclass.dsl_option_names.dup
+            else
+              Set.new
+            end
+        end
+
+        private
+
+        def add_option_name(name)
+          dsl_option_names << name
+        end
+
+        def define_accessor(name)
+          ivar = :"@#{name}"
+          define_method(name) do |value = nil|
+            value ? instance_variable_set(ivar, value) : instance_variable_get(ivar)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/avro/builder/errors.rb
+++ b/lib/avro/builder/errors.rb
@@ -37,5 +37,16 @@ module Avro
         ' Try specifying the full namespace.' unless name.to_s.index('.')
       end
     end
+
+    class UnsupportedBlockAttributeError < StandardError
+      def initialize(attribute:, type:, field: nil)
+        target = if field
+                   "field '#{field}' of type :#{type}"
+                 else
+                   "type :#{type}"
+                 end
+        super("'#{attribute}' must be set directly using an option on #{target}")
+      end
+    end
   end
 end

--- a/lib/avro/builder/errors.rb
+++ b/lib/avro/builder/errors.rb
@@ -40,12 +40,8 @@ module Avro
 
     class UnsupportedBlockAttributeError < StandardError
       def initialize(attribute:, type:, field: nil)
-        target = if field
-                   "field '#{field}' of type :#{type}"
-                 else
-                   "type :#{type}"
-                 end
-        super("'#{attribute}' must be set directly using an option on #{target}")
+        super("'#{attribute}' must be set directly using an option on "\
+              "field '#{field}' of type :#{type}")
       end
     end
   end

--- a/lib/avro/builder/errors.rb
+++ b/lib/avro/builder/errors.rb
@@ -40,8 +40,13 @@ module Avro
 
     class UnsupportedBlockAttributeError < StandardError
       def initialize(attribute:, type:, field: nil)
-        super("'#{attribute}' must be set directly using an option on "\
-              "field '#{field}' of type :#{type}")
+        target = if field
+                   "field '#{field}' of type :#{type}"
+                 else
+                   "type :#{type}"
+                 end
+        super("'#{attribute}' must be set directly using an option on #{target}, "\
+              'not via a block')
       end
     end
   end

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -1,4 +1,5 @@
 require 'avro/builder/type_factory'
+require 'avro/builder/aliasable'
 
 module Avro
   module Builder
@@ -8,11 +9,14 @@ module Avro
     class Field
       include Avro::Builder::DslAttributes
       include Avro::Builder::TypeFactory
+      include Avro::Builder::Aliasable
 
       INTERNAL_ATTRIBUTES = Set.new(%i(optional_field)).freeze
 
       # These attributes may be set as options or via a block in the DSL
-      dsl_attributes :doc, :aliases, :default, :order
+      dsl_attributes :doc, :default, :order
+
+      attr_reader :name
 
       def initialize(name:, type_name:, record:, cache:, internal: {}, options: {}, &block)
         @cache = cache
@@ -23,8 +27,9 @@ module Avro
           send("#{key}=", value) if INTERNAL_ATTRIBUTES.include?(key)
         end
 
-        options.each do |key, value|
-          send(key, value) if dsl_attribute?(key)
+        type_options = options.dup
+        options.keys.each do |key|
+          send(key, type_options.delete(key)) if dsl_attribute?(key)
         end
 
         @type = if builtin_type?(type_name)
@@ -32,26 +37,24 @@ module Avro
                                                     field: self,
                                                     cache: cache,
                                                     internal: internal,
-                                                    options: options)
+                                                    options: type_options)
                 else
-                  named_type = true
                   cache.lookup_named_type(type_name, namespace)
                 end
 
         # DSL calls must be evaluated after the type has been constructed
         instance_eval(&block) if block_given?
         @type.validate!
-        @type.cache! unless named_type
       end
 
       ## Delegate additional DSL calls to the type
 
-      def respond_to_missing?(id, include_all = false)
-        super || type.respond_to?(id, include_all)
+      def respond_to_missing?(id, _include_all)
+        type.dsl_respond_to?(id) || super
       end
 
       def method_missing(id, *args, &block)
-        type.respond_to?(id) ? type.send(id, *args, &block) : super
+        type.dsl_respond_to?(id) ? type.send(id, *args, &block) : super
       end
 
       def name_fragment
@@ -62,7 +65,9 @@ module Avro
       # and return the namespace value from the enclosing record.
       def namespace(value = nil)
         if value
-          type.namespace(value)
+          raise UnsupportedBlockAttributeError.new(attribute: :namespace,
+                                                   field: @name,
+                                                   type: type.type_name)
         else
           record.namespace
         end
@@ -71,7 +76,9 @@ module Avro
       # Delegate setting name explicitly via DSL to type
       def name(value = nil)
         if value
-          type.name(value)
+          raise UnsupportedBlockAttributeError.new(attribute: :name,
+                                                   field: @name,
+                                                   type: type.type_name)
         else
           # Return the name of the field
           @name
@@ -79,6 +86,7 @@ module Avro
       end
 
       def serialize(reference_state)
+        # TODO: order is not included here
         {
           name: name,
           type: serialized_type(reference_state),

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -12,7 +12,7 @@ module Avro
       include Avro::Builder::TypeFactory
       include Avro::Builder::Aliasable
 
-      INTERNAL_ATTRIBUTES = Set.new(%i(optional_field)).freeze
+      INTERNAL_ATTRIBUTES = %i(optional_field).to_set.freeze
 
       # These attributes may be set as options or via a block in the DSL
       dsl_attributes :doc, :default, :order

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -7,6 +7,7 @@ module Avro
     # This class represents a field in a record.
     # A field must be initialized with a type.
     class Field
+      include Avro::Builder::DslOptions
       include Avro::Builder::DslAttributes
       include Avro::Builder::TypeFactory
       include Avro::Builder::Aliasable

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -31,6 +31,7 @@ module Avro
                                             &block)
         create_builtin_type(type_name, field: field, cache: cache).tap do |type|
           type.configure_options(internal.merge(options))
+          type.cache!
           type.instance_eval(&block) if block_given?
         end
       end

--- a/lib/avro/builder/types/configurable_type.rb
+++ b/lib/avro/builder/types/configurable_type.rb
@@ -2,12 +2,12 @@ module Avro
   module Builder
     module Types
 
-      # This concern is used by Types that can be configured using DSL
-      # attributes.
+      # This concern is used by Types that can be configured via the DSL.
+      # Only attributes that can be set via options are configured here.
       module ConfigurableType
         def configure_options(options = {})
           options.each do |key, value|
-            send(key, value) if dsl_attribute?(key)
+            send(key, value) if dsl_option?(key)
           end
         end
       end

--- a/lib/avro/builder/types/configurable_type.rb
+++ b/lib/avro/builder/types/configurable_type.rb
@@ -7,7 +7,7 @@ module Avro
       module ConfigurableType
         def configure_options(options = {})
           options.each do |key, value|
-            send(key, value) if dsl_option?(key)
+            send("#{key}=", value) if dsl_option?(key)
           end
         end
       end

--- a/lib/avro/builder/types/named_type.rb
+++ b/lib/avro/builder/types/named_type.rb
@@ -1,5 +1,6 @@
 require 'avro/builder/types/configurable_type'
 require 'avro/builder/namespaceable'
+require 'avro/builder/aliasable'
 
 module Avro
   module Builder
@@ -11,16 +12,19 @@ module Avro
         include Avro::Builder::Types::ComplexType
         include Avro::Builder::Namespaceable
         include Avro::Builder::Types::ConfigurableType
+        include Avro::Builder::Aliasable
 
-        dsl_attributes :namespace, :aliases
+        dsl_option :namespace
 
-        dsl_attribute :name do |value = nil|
+        dsl_option :name do |value = nil|
           if value
             @name = value
           else
             @name || "__#{name_fragment}_#{type_name}"
           end
         end
+
+        dsl_attribute_alias :type_aliases, :aliases
 
         def validate!
           required_attribute_error!(:name) if field.nil? && @name.nil?

--- a/lib/avro/builder/types/named_type.rb
+++ b/lib/avro/builder/types/named_type.rb
@@ -15,13 +15,8 @@ module Avro
         include Avro::Builder::Aliasable
 
         dsl_option :namespace
-
-        dsl_option :name do |value = nil|
-          if value
-            @name = value
-          else
-            @name || "__#{name_fragment}_#{type_name}"
-          end
+        dsl_option :name do
+          @name || "__#{name_fragment}_#{type_name}"
         end
 
         dsl_attribute_alias :type_aliases, :aliases

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -5,7 +5,7 @@ module Avro
       # at the top-level or as the type for a field in a record.
       class RecordType < Avro::Builder::Types::NamedType
 
-        DSL_METHODS = Set.new(%i(required optional extends)).freeze
+        DSL_METHODS = %i(required optional extends).to_set.freeze
 
         dsl_attribute :doc
         dsl_attribute_alias :type_doc, :doc

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -5,7 +5,10 @@ module Avro
       # at the top-level or as the type for a field in a record.
       class RecordType < Avro::Builder::Types::NamedType
 
-        dsl_attributes :doc
+        DSL_METHODS = Set.new(%i(required optional extends)).freeze
+
+        dsl_attribute :doc
+        dsl_attribute_alias :type_doc, :doc
 
         def initialize(name = nil, options: {}, cache:, field: nil, &block)
           @type_name = :record
@@ -15,6 +18,10 @@ module Avro
 
           configure_options(options)
           instance_eval(&block) if block_given?
+        end
+
+        def dsl_method?(name)
+          DSL_METHODS.include?(name)
         end
 
         # Add a required field to the record

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -42,6 +42,17 @@ module Avro
         def cache!
         end
 
+        # Subclasses can override this method to indicate that the name
+        # is a method that the type exposes in the DSL. These methods are in
+        # addition to the methods for setting attributes on a type.
+        def dsl_method?(_name)
+          false
+        end
+
+        def dsl_respond_to?(name)
+          dsl_attribute?(name) || dsl_method?(name)
+        end
+
         private
 
         def required_attribute_error!(attribute_name)

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -5,6 +5,7 @@ module Avro
       # type is constructed. The type has no additional attributes, and
       # the type is serialized as just the type name.
       class Type
+        include Avro::Builder::DslOptions
         include Avro::Builder::DslAttributes
 
         attr_reader :type_name

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/spec/avro/builder/file_handler_spec.rb
+++ b/spec/avro/builder/file_handler_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Avro::Builder::FileHandler do
-  before do
-    Avro::Builder.add_load_path('spec/avro/dsl')
-  end
-
   context "loading external references" do
     subject do
       Avro::Builder.build do

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -327,6 +327,34 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "record with name via block" do
+    subject do
+      described_class.build do
+        record do
+          name :invalid
+          required :i, :int
+        end
+      end
+    end
+    it "raises an error" do
+      expect { subject }.to raise_error(Avro::Builder::UnsupportedBlockAttributeError)
+    end
+  end
+
+  context "record with namespace via block" do
+    subject do
+      described_class.build do
+        record :foo do
+          namespace :invalid
+          required :i, :int
+        end
+      end
+    end
+    it "raises an error" do
+      expect { subject }.to raise_error(Avro::Builder::UnsupportedBlockAttributeError)
+    end
+  end
+
   context "record with inline enum" do
     subject do
       described_class.build do
@@ -1044,15 +1072,15 @@ describe Avro::Builder do
         },
                  {
                    name: :C,
-                   type: {
-                     name: :__A_C_record,
-                     namespace: 'com.example',
-                     type: :record,
-                     fields: [
-                       { name: :b, type: [:null, :bytes], default: nil }
-                     ]
-                   },
-                   doc: 'This record has a unique generated name'
+                    type: {
+                      name: :__A_C_record,
+                      namespace: 'com.example',
+                      type: :record,
+                      fields: [
+                        { name: :b, type: [:null, :bytes], default: nil }
+                      ]
+                    },
+                    doc: 'This record has a unique generated name'
                  }]
       }
     end
@@ -1087,6 +1115,38 @@ describe Avro::Builder do
       }
     end
     it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "inline record named via block" do
+    subject do
+      described_class.build do
+        record :my_rec, namespace: 'com.example' do
+          required :nested, :record do
+            name :nested_rec
+            required :s, :string
+          end
+        end
+      end
+    end
+    it "raises an error" do
+      expect { subject }.to raise_error(Avro::Builder::UnsupportedBlockAttributeError)
+    end
+  end
+
+  context "inline record namespaced via block" do
+    subject do
+      described_class.build do
+        record :my_rec, namespace: 'com.example' do
+          required :nested, :record do
+            namespace 'com.example.sub'
+            required :s, :string
+          end
+        end
+      end
+    end
+    it "raises an error" do
+      expect { subject }.to raise_error(Avro::Builder::UnsupportedBlockAttributeError)
+    end
   end
 
   context "ambiguous reference requiring namespacing" do

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -41,8 +41,7 @@ describe Avro::Builder do
   context "enum type with options" do
     subject do
       described_class.build do
-        enum :enum2, :ONE, :TWO do
-          namespace 'com.example'
+        enum :enum2, :ONE, :TWO, namespace: 'com.example' do
           doc 'Example Enum'
           aliases %w(Foo Bar)
         end
@@ -100,8 +99,7 @@ describe Avro::Builder do
   context "enum with block" do
     subject do
       described_class.build do
-        enum do
-          name :enum3
+        enum name: :enum3 do
           symbols :A, :B
         end
       end
@@ -181,10 +179,9 @@ describe Avro::Builder do
   context "fixed type with options" do
     subject do
       described_class.build do
-        fixed :seven do
+        fixed :seven, namespace: 'com.example' do
           size 7
-          aliases ['MoreThanSix']
-          namespace 'com.example'
+          aliases 'MoreThanSix'
         end
       end
     end
@@ -203,8 +200,7 @@ describe Avro::Builder do
   context "fixed with block" do
     subject do
       described_class.build do
-        fixed do
-          name :eight
+        fixed :eight do
           size 9
         end
       end
@@ -335,8 +331,7 @@ describe Avro::Builder do
     subject do
       described_class.build do
         record :with_enum do
-          required :e1, :enum do
-            name :e_enum
+          required :e1, :enum, name: :e_enum do
             symbols :A, :B
           end
           required :e2, :enum, symbols: [:X, :Y]
@@ -360,8 +355,7 @@ describe Avro::Builder do
     subject do
       described_class.build do
         record :with_fixed do
-          required :f1, :fixed do
-            name :f5
+          required :f1, :fixed, name: :f5 do
             size 5
           end
           required :f2, :fixed, size: 6
@@ -915,13 +909,11 @@ describe Avro::Builder do
   context "record with subrecord reference" do
     subject do
       described_class.build do
-        record :sub_rec do
-          namespace 'com.example.A'
+        record :sub_rec, namespace: 'com.example.A' do
           required :i, :int
         end
 
-        record :top_rec do
-          namespace 'com.example.B'
+        record :top_rec, namespace: 'com.example.B' do
           required :sub, 'com.example.A.sub_rec'
         end
       end
@@ -984,8 +976,7 @@ describe Avro::Builder do
         namespace 'com.example'
 
         record :my_rec do
-          required :nested, :record do
-            namespace 'com.example.sub'
+          required :nested, :record, namespace: 'com.example.sub' do
             required :s, :string
           end
         end
@@ -1072,10 +1063,8 @@ describe Avro::Builder do
   context "inline, named, nested record" do
     subject do
       described_class.build do
-        record :my_rec do
-          namespace 'com.example'
-          required :nested, :record do
-            name :nested_rec
+        record :my_rec, namespace: 'com.example' do
+          required :nested, :record, name: :nested_rec do
             required :s, :string
           end
         end
@@ -1179,4 +1168,178 @@ describe Avro::Builder do
     end
     it { is_expected.to be_json_eql(expected.to_json) }
   end
+
+  context "recursive example" do
+    # this is an example from the Avro specification
+    subject do
+      described_class.build do
+        record :LongList, aliases: :LinkedLongs do
+          required :value, :long
+          optional :next, :LongList
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :LongList,
+        aliases: [:LinkedLongs],
+        fields: [
+          { type: :long, name: :value },
+          { type: [:null, :LongList], name: :next, default: nil }
+        ]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "a field with aliases and a type with aliases" do
+    subject do
+      described_class.build do
+        record :all_the_aliases, aliases: [:top_level] do
+          required :rec, :record, name: :aliased_rec, aliases: :field_alias do
+            type_aliases [:alias_rec]
+            required :i, :int
+          end
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :all_the_aliases,
+        aliases: [:top_level],
+        fields: [
+          {
+            name: :rec,
+            aliases: [:field_alias],
+            type: {
+              name: :aliased_rec,
+              type: :record,
+              aliases: [:alias_rec],
+              fields: [{ name: :i, type: :int }]
+            }
+          }
+        ]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "doc option on field" do
+    subject do
+      described_class.build do
+        record :with_documented_field do
+          required :f, :record, doc: 'field documentation' do
+            required :i, :int
+          end
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_documented_field,
+        fields: [{
+          name: :f,
+          doc: 'field documentation',
+          type: {
+            type: :record,
+            name: :__with_documented_field_f_record,
+            fields: [{ name: :i, type: :int }]
+          }
+        }]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+
+    context "doc attribute on field" do
+      subject do
+        described_class.build do
+          record :with_documented_field do
+            required :f, :record do
+              doc 'field documentation'
+              required :i, :int
+            end
+          end
+        end
+      end
+      let(:expected) do
+        {
+          type: :record,
+          name: :with_documented_field,
+          fields: [{
+            name: :f,
+            doc: 'field documentation',
+            type: {
+              type: :record,
+              name: :__with_documented_field_f_record,
+              fields: [{ name: :i, type: :int }]
+            }
+          }]
+        }
+      end
+      it { is_expected.to be_json_eql(expected.to_json) }
+    end
+
+    context "doc option on inline type" do
+      subject do
+        described_class.build do
+          record :with_documented_field do
+            required :f, :record, type_doc: 'inline type doc' do
+              required :i, :int
+            end
+          end
+        end
+      end
+      let(:expected) do
+        {
+          type: :record,
+          name: :with_documented_field,
+          fields: [{
+            name: :f,
+            type: {
+              type: :record,
+              name: :__with_documented_field_f_record,
+              doc: 'inline type doc',
+              fields: [{ name: :i, type: :int }]
+            }
+          }]
+        }
+      end
+      it { is_expected.to be_json_eql(expected.to_json) }
+    end
+  end
+
+  context "doc attribute on field and inline type" do
+    subject do
+      described_class.build do
+        record :with_documented_field do
+          required :f, :record do
+            doc 'field documentation'
+            type_doc 'inline type doc'
+            required :i, :int
+          end
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_documented_field,
+        fields: [{
+          name: :f,
+          doc: 'field documentation',
+          type: {
+            type: :record,
+            name: :__with_documented_field_f_record,
+            doc: 'inline type doc',
+            fields: [{ name: :i, type: :int }]
+          }
+        }]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
 end

--- a/spec/avro/dsl/other/ambiguous.rb
+++ b/spec/avro/dsl/other/ambiguous.rb
@@ -1,4 +1,3 @@
-record :ambiguous do
-  namespace :other
+record :ambiguous, namespace: :other do
   required :i, :int
 end

--- a/spec/avro/dsl/test/ambiguous.rb
+++ b/spec/avro/dsl/test/ambiguous.rb
@@ -1,4 +1,3 @@
-record :ambiguous do
-  namespace :test
+record :ambiguous, namespace: :test do
   required :i, :int
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,9 @@ require 'simplecov'
 SimpleCov.start
 
 require 'avro/builder'
+
+RSpec.configure do |config|
+  config.before do
+    Avro::Builder.add_load_path('spec/avro/dsl')
+  end
+end


### PR DESCRIPTION
These changes support:

### recursive types
```ruby
record :my_type do
  required :i, :int
  optional :next, :my_type
end
```

### aliases specified as a single value or an array
```ruby
enum :action, :CREATE, :UPDATE, aliases: :operation
enum :days, :SAT, :SUN, aliases: [:weekend_days, :weekend]
```

### only allow `name` and `namespace` to be set as options:
```ruby
# no longer supported
record do
  name: :my_rec
  namespace: :test
  ...
end

# supported
record :my_rec, namespace: :test do
  ...
end

# also supported
record :top
  required :record, name: :inside_rec do
    ...
  end
end
```

### support `doc` and `aliases` attributes on both field and inline type
```ruby
record :with_inlines do
  required :first, :record, doc: 'field doc', type_doc: 'record type doc' do
    ...
  end
  required :magic, :fixed, size: 4, aliases: :magic_byte, type_aliases: :magic_fixed 
end

# these also work
record :with_inlines do
  required :first, :record  do
    doc 'field doc', 
    type_doc 'record type doc'
    ...
  end
  required :magic, :fixed, size: 4 do
    aliases: :magic_byte
    type_aliases: :magic_fixed
  end 
end
```

To support these restrictions on where attributes can be set a `DslOption` module is introduced with methods to define attributes that can only be set as options.

README update are likely needed here too but I'd like do that as a follow-up task.

Prime: @jturkel 