### PR TITLE
Implement schema store

### DIFF
--- a/lib/avro/builder.rb
+++ b/lib/avro/builder.rb
@@ -1,8 +1,14 @@
 require 'avro/builder/version'
 require 'avro/builder/dsl'
+require 'avro/builder/schema_store'
 
 module Avro
   module Builder
+    class SchemaError < StandardError; end
+
+    def self.find(filename)
+      Avro::Builder::DSL.new(filename: filename).as_schema
+    end
 
     # Accepts a string or block to eval to define a JSON schema
     def self.build(str = nil, &block)

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -27,7 +27,8 @@ module Avro
 
       # An instance of the DSL is initialized with a string or a block to
       # evaluate to define Avro schema objects.
-      def initialize(str = nil, &block)
+      def initialize(str = nil, filename: nil, &block)
+        return eval_file(filename) if filename
         str ? instance_eval(str) : instance_eval(&block)
       end
 

--- a/lib/avro/builder/schema_store.rb
+++ b/lib/avro/builder/schema_store.rb
@@ -1,0 +1,20 @@
+module Avro
+  module Builder
+    class SchemaStore
+      def initialize(path: nil)
+        Avro::Builder.add_load_path(path) if path
+        @schemas = {}
+      end
+
+      def find(name, namespace = nil)
+        fullname = Avro::Name.make_fullname(name, namespace)
+
+        @schemas[fullname] ||= Avro::Builder.find(fullname).tap do |schema|
+          if schema.respond_to?(:fullname) && schema.fullname != fullname
+            raise Avro::Builder::SchemaError, "expected schema `#{name}' to define type `#{fullname}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/avro/builder/schema_store_spec.rb
+++ b/spec/avro/builder/schema_store_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Avro::Builder::SchemaStore do
+  describe '#find' do
+    subject { schema_store.find(name, namespace) }
+
+    let(:schema_store) { described_class.new }
+    let(:name) { 'with_array' }
+    let(:namespace) { 'test' }
+
+    context 'dsl directory has not been added to build path' do
+      before do
+        allow(Avro::Builder::DSL).to receive(:load_paths) { Set.new }
+      end
+
+      it 'raises file not found exception' do
+        expect{ subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'dsl directory has been added to build path' do
+      it { is_expected.to be_a(Avro::Schema) }
+
+      context 'schema has already been requested' do
+        before do
+          schema_store.find(name, namespace)
+        end
+
+        it 'uses cached schema' do
+          expect(Avro::Builder).to_not receive(:find)
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1591,4 +1591,23 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  describe '.find' do
+    subject { described_class.find(filename) }
+
+    let(:filename) { 'with_array' }
+
+    context 'dsl directory has not been added to build path' do
+      before do
+        allow(Avro::Builder::DSL).to receive(:load_paths) { Set.new }
+      end
+
+      it 'raises file not found exception' do
+        expect{ subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'dsl directory has been added to build path' do
+      it { is_expected.to be_a(Avro::Schema) }
+    end
+  end
 end


### PR DESCRIPTION
I may be missing something, but it doesn't seem like there is an easy way to define schemas using the DSL and use those files with a schema store at runtime. This PR adds a simple schema store that implements the `find` method and searches the builds paths for a match.

Usage:
```
Avromatic.configure do |avro|
  avro.schema_store = Avro::Builder::SchemaStore.new(path: 'app/models/dsl')
  avro.registry_url = 'tcp://blueapron:avro@localhost:21000'
  avro.build_messaging!
end
```