### PR TITLE
Support locally defined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-builder changelog
 
+## v0.12.0
+- Allow methods for complex and primitive types to be used at the top-level and
+  anywhere that a type name is accepted.
+
 ## v0.11.0
 - Add support for generating schemas that contain logical types. The official
   Ruby `avro` gem does not yet support logical types. The `avro-salsify-fork` gem

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ record :complex_types do
 end
 ```
 
+Methods may also be used for complex types instead of separately specifying the
+type name and options:
+
+```ruby
+record :complex_types do
+  required :array_of_unions, array(union(:int, :string))
+  required :array_or_map, union(array(:int), map(:int))
+end
+```
+
 For more on unions see [below](#unions).
 
 ### Nested Records
@@ -253,6 +263,16 @@ end
 
 For an optional union, `null` is automatically added as the first type for
 the union and the field defaults to `null`.
+
+Unions may also be defined using the `union` method instead of specifying the
+`:union` type and member types separately:
+
+```ruby
+record :my_record_with_unions do
+  required :req_union, union(:string, :int)
+  optional :opt_union, union(:float, :long)
+end
+```
 
 ### Logical Types
 

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -22,7 +22,7 @@ module Avro
       include Avro::Builder::DslOptions
       include Avro::Builder::DslAttributes
       include Avro::Builder::FileHandler
-      include Avro::Builder::TypeFactory
+      include Avro::Builder::AnonymousTypes
 
       dsl_attribute :namespace
 
@@ -81,6 +81,12 @@ module Avro
 
       def as_schema
         Avro::Schema.parse(to_json(validate: false))
+      end
+
+      # Override the type method from AnonymousTypes to store a reference to the
+      # last type defined.
+      def type(*)
+        @last_object = super
       end
 
       private

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -31,7 +31,9 @@ module Avro
           send(key, type_options.delete(key)) if dsl_attribute?(key)
         end
 
-        @field_type = type_dispatch(avro_type_or_name, namespace) do |avro_type_name|
+        # Find existing Type or build a new instance of a builtin Type using
+        # the supplied block
+        @field_type = type_lookup(avro_type_or_name, namespace) do |avro_type_name|
           create_and_configure_builtin_type(avro_type_name,
                                             field: self,
                                             cache: cache,

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -10,6 +10,16 @@ module Avro
 
       private
 
+      def type_dispatch(avro_type_or_name, namespace = nil)
+        if avro_type_or_name.is_a?(Avro::Builder::Types::Type)
+          avro_type_or_name
+        elsif builtin_type?(avro_type_or_name)
+          yield(avro_type_or_name)
+        else
+          cache.lookup_named_type(avro_type_or_name, namespace)
+        end
+      end
+
       # Return a new Type instance
       def create_builtin_type(avro_type_name, field:, cache:)
         name = avro_type_name.to_s.downcase

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -10,7 +10,12 @@ module Avro
 
       private
 
-      def type_dispatch(avro_type_or_name, namespace = nil)
+      # Determine if avro_type_or_name is an existing Type, the name of a builtin
+      # type or a previously defined named type.
+      # If avro_type_or_name is the name of a builtin type, then that type name
+      # is yielded to build the type using a block provided by the caller using,
+      # for example, create_builtin_type or create_and_configure_builtin_type.
+      def type_lookup(avro_type_or_name, namespace = nil)
         if avro_type_or_name.is_a?(Avro::Builder::Types::Type)
           avro_type_or_name
         elsif builtin_type?(avro_type_or_name)

--- a/lib/avro/builder/types/array_type.rb
+++ b/lib/avro/builder/types/array_type.rb
@@ -7,7 +7,7 @@ module Avro
 
         dsl_attribute :items do |items_type = nil|
           if items_type
-            @items = create_builtin_or_lookup_named_type(items_type)
+            @items = create_builtin_or_lookup_type(items_type)
           else
             @items
           end

--- a/lib/avro/builder/types/complex_type.rb
+++ b/lib/avro/builder/types/complex_type.rb
@@ -26,6 +26,10 @@ module Avro
           }.merge(overrides).reject { |_, v| v.nil? }
         end
 
+        def to_h(reference_state)
+          serialize(reference_state)
+        end
+
         module ClassMethods
 
           # Infer avro_type_name based on class

--- a/lib/avro/builder/types/map_type.rb
+++ b/lib/avro/builder/types/map_type.rb
@@ -7,7 +7,7 @@ module Avro
 
         dsl_attribute :values do |value_type = nil|
           if value_type
-            @values = create_builtin_or_lookup_named_type(value_type)
+            @values = create_builtin_or_lookup_type(value_type)
           else
             @values
           end

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -26,9 +26,9 @@ module Avro
         end
 
         # Add a required field to the record
-        def required(name, avro_type_name, options = {}, &block)
+        def required(name, avro_type_or_name, options = {}, &block)
           new_field = Avro::Builder::Field.new(name: name,
-                                               avro_type_name: avro_type_name,
+                                               avro_type_or_name: avro_type_or_name,
                                                record: self,
                                                cache: cache,
                                                internal: { type_namespace: namespace },
@@ -39,9 +39,9 @@ module Avro
 
         # Add an optional field to the record. In Avro this is represented
         # as a union of null and the type specified here.
-        def optional(name, avro_type_name, options = {}, &block)
+        def optional(name, avro_type_or_name, options = {}, &block)
           new_field = Avro::Builder::Field.new(name: name,
-                                               avro_type_name: avro_type_name,
+                                               avro_type_or_name: avro_type_or_name,
                                                record: self,
                                                cache: cache,
                                                internal: { type_namespace: namespace,

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -26,6 +26,11 @@ module Avro
           end
         end
 
+        def to_h(_reference_state)
+          { type: avro_type_name, logicalType: logical_type }
+            .reject { |_, v| v.nil? }
+        end
+
         def namespace
           nil
         end

--- a/lib/avro/builder/types/type_referencer.rb
+++ b/lib/avro/builder/types/type_referencer.rb
@@ -8,8 +8,12 @@ module Avro
       module TypeReferencer
         include Avro::Builder::TypeFactory
 
-        def create_builtin_or_lookup_named_type(avro_type_or_name)
-          type_dispatch(avro_type_or_name) do |avro_type_name|
+        private
+
+        def create_builtin_or_lookup_type(avro_type_or_name)
+          # Find existing Type or build a new instance of a builtin Type using
+          # the supplied block
+          type_lookup(avro_type_or_name) do |avro_type_name|
             create_builtin_type(avro_type_name, field: field, cache: cache)
           end
         end

--- a/lib/avro/builder/types/type_referencer.rb
+++ b/lib/avro/builder/types/type_referencer.rb
@@ -9,12 +9,8 @@ module Avro
         include Avro::Builder::TypeFactory
 
         def create_builtin_or_lookup_named_type(avro_type_or_name)
-          if avro_type_or_name.is_a?(Avro::Builder::Types::Type)
-            avro_type_or_name
-          elsif builtin_type?(avro_type_or_name)
-            create_builtin_type(avro_type_or_name, field: field, cache: cache)
-          else
-            cache.lookup_named_type(avro_type_or_name)
+          type_dispatch(avro_type_or_name) do |avro_type_name|
+            create_builtin_type(avro_type_name, field: field, cache: cache)
           end
         end
       end

--- a/lib/avro/builder/types/union_type.rb
+++ b/lib/avro/builder/types/union_type.rb
@@ -9,7 +9,7 @@ module Avro
 
         dsl_attribute :types do |*types|
           if !types.empty?
-            @types = types.flatten.map { |type| create_builtin_or_lookup_named_type(type) }
+            @types = types.flatten.map { |type| create_builtin_or_lookup_type(type) }
           else
             @types
           end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.11.0'.freeze
+    VERSION = '0.12.0'.freeze
   end
 end


### PR DESCRIPTION
This change allows methods for primitive types and complex types to be used anywhere that a type name and options can be used.

The primary use case for this is to locally reuse a type that cannot be named, e.g.:

```ruby
timestamp = long(logical_type: 'timestamp-micros')

record :object do
  required :created_at, timestamp
  required :updated_at, timestamp
  ...
end
```

Prime: @jturkel 