### PR TITLE
Add support for user-defined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # avro-builder changelog
 
 ## v0.13.0
-- Add support for user-defined types.
+- Add support for type macros.
 
 ## v0.12.0
 - Allow methods for complex and primitive types to be used at the top-level and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-builder changelog
 
+## v0.13.0
+- Add support for user-defined types.
+
 ## v0.12.0
 - Allow methods for complex and primitive types to be used at the top-level and
   anywhere that a type name is accepted.

--- a/README.md
+++ b/README.md
@@ -316,19 +316,27 @@ record :with_date_array
 end
 ```
 
-### User-defined Types
+### Type Macros
 
-`avro-builder` allows a name to be associated with types that are not usually
-named in Avro schemas. This name will not be retained in the generated schema
-but it allows definitions to be reused across DSL files:
+`avro-builder` allows type macros to be defined that expand to types that
+cannot normally be named in Avro schemas. These macro names are not retained
+in generated schemas but allow definitions to be reused across DSL files:
 
 ```ruby
-define_type(:timestamp, long(logical_type: 'timestamp-millis'))
+type_macro :timestamp, long(logical_type: 'timestamp-millis')
 
 record :user do
   required :created_at, :timestamp
   required :updated_at, :timestamp
 end
+```
+
+Type macros inherit the namespace from the context where they are defined or
+an explicit namespace option may be specified:
+
+```ruby
+type_macro :timestamp, long(logical_type: 'timestamp-millis'),
+           namespace: 'com.my_company'
 ```
 
 ### Auto-loading and Imports

--- a/README.md
+++ b/README.md
@@ -316,6 +316,21 @@ record :with_date_array
 end
 ```
 
+### User-defined Types
+
+`avro-builder` allows a name to be associated with types that are not usually
+named in Avro schemas. This name will not be retained in the generated schema
+but it allows definitions to be reused across DSL files:
+
+```ruby
+define_type(:timestamp, long(logical_type: 'timestamp-millis'))
+
+record :user do
+  required :created_at, :timestamp
+  required :updated_at, :timestamp
+end
+```
+
 ### Auto-loading and Imports
 
 Specify paths to search for definitions:

--- a/lib/avro/builder/definition_cache.rb
+++ b/lib/avro/builder/definition_cache.rb
@@ -32,6 +32,18 @@ module Avro
         object || lookup_named_type(key, nil)
       end
 
+      # Add a type object directly with the specified name.
+      # The type_object may not have a name or namespace.
+      def add_type_by_name(name, type_object)
+        key = name.to_s
+        if schema_objects.key?(key)
+          raise DuplicateDefinitionError.new(key, type_object, schema_objects[key])
+        else
+          schema_names.add(key)
+          schema_objects.store(key, type_object)
+        end
+      end
+
       private
 
       # Schemas are stored by name, provided that the name is unique.

--- a/lib/avro/builder/definition_cache.rb
+++ b/lib/avro/builder/definition_cache.rb
@@ -48,20 +48,18 @@ module Avro
       # If the unqualified name is ambiguous then it is removed from the cache.
       # A set of unqualified names is kept to avoid reloading files for
       # ambiguous references.
-      def store_by_name(object, name = nil)
-        key = name || object.name.to_s
-        if schema_objects.key?(key)
-          schema_objects.delete(key)
-        elsif !schema_names.include?(key)
-          schema_objects.store(key, object)
+      def store_by_name(object, name = object.name.to_s)
+        if schema_objects.key?(name)
+          schema_objects.delete(name)
+        elsif !schema_names.include?(name)
+          schema_objects.store(name, object)
         end
-        schema_names.add(key)
+        schema_names.add(name)
       end
 
-      def store_by_fullname(object, fullname = nil)
-        key = fullname || object.fullname
-        raise DuplicateDefinitionError.new(key, object, schema_objects[key]) if schema_objects.key?(key)
-        schema_objects.store(key, object)
+      def store_by_fullname(object, fullname = object.fullname)
+        raise DuplicateDefinitionError.new(fullname, object, schema_objects[fullname]) if schema_objects.key?(fullname)
+        schema_objects.store(fullname, object)
       end
 
       attr_reader :schema_objects, :schema_names, :builder

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -89,22 +89,9 @@ module Avro
         @last_object = super
       end
 
-      # Several variants:
-      # define_type(:foo, long)
-      # define_type(:bar, { namespace: 'com.example' }, long)
-      # define_type(:baz, 'com.example', long)
-      # define_type('foo.bar', long)
-      def define_type(name, *other)
-        type_object = other.last
+      def type_macro(name, type_object, options = {})
         raise "#{type_object.inspect} must be a type object" unless type_object.is_a?(Types::Type)
-        options = case other.first
-                  when Hash
-                    other.first
-                  when String, Symbol
-                    { namespace: other.first }
-                  else
-                    {}
-                  end
+        raise "namespace cannot be included in name: #{name}" if name.to_s.index('.')
         cache.add_type_by_name(type_object, name, options[:namespace] || namespace)
       end
 

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -89,6 +89,10 @@ module Avro
         @last_object = super
       end
 
+      def define_type(name, type_object)
+        cache.add_type_by_name(name, type_object)
+      end
+
       private
 
       def cache

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -89,8 +89,23 @@ module Avro
         @last_object = super
       end
 
-      def define_type(name, type_object)
-        cache.add_type_by_name(name, type_object)
+      # Several variants:
+      # define_type(:foo, long)
+      # define_type(:bar, { namespace: 'com.example' }, long)
+      # define_type(:baz, 'com.example', long)
+      # define_type('foo.bar', long)
+      def define_type(name, *other)
+        type_object = other.last
+        raise "#{type_object.inspect} must be a type object" unless type_object.is_a?(Types::Type)
+        options = case other.first
+                  when Hash
+                    other.first
+                  when String, Symbol
+                    { namespace: other.first }
+                  else
+                    {}
+                  end
+        cache.add_type_by_name(type_object, name, options[:namespace] || namespace)
       end
 
       private

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.13.0.rc0'.freeze
+    VERSION = '0.13.0'.freeze
   end
 end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.12.0'.freeze
+    VERSION = '0.13.0.rc0'.freeze
   end
 end

--- a/spec/avro/builder_user_defined_types_spec.rb
+++ b/spec/avro/builder_user_defined_types_spec.rb
@@ -1,0 +1,43 @@
+describe Avro::Builder, 'user_defined_types' do
+  context "user-defined type defined locally" do
+    subject(:schema_json) do
+      described_class.build do
+        define_type(:timestamp, long(logical_type: 'timestamp-millis'))
+
+        record :user do
+          required :created_at, :timestamp
+          required :updated_at, :timestamp
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :user,
+        fields: [
+          { name: :created_at, type: { type: :long, logicalType: 'timestamp-millis' } },
+          { name: :updated_at, type: { type: :long, logicalType: 'timestamp-millis' } }
+        ]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "user defined type from a file" do
+    subject(:schema_json) do
+      described_class.build do
+        record :with_date do
+          required :d, :date
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_date,
+        fields: [{ name: :d, type: { type: :int, logicalType: :date } }]
+      }
+    end
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+end

--- a/spec/avro/builder_user_defined_types_spec.rb
+++ b/spec/avro/builder_user_defined_types_spec.rb
@@ -1,4 +1,15 @@
 describe Avro::Builder, 'user_defined_types' do
+  context "without a type object" do
+    let(:schema_json) do
+      described_class.build do
+        define_type(:num, :int)
+      end
+    end
+    it "raises an error" do
+      expect { schema_json }.to raise_error(':int must be a type object')
+    end
+  end
+
   context "user-defined type defined locally" do
     subject(:schema_json) do
       described_class.build do
@@ -21,6 +32,60 @@ describe Avro::Builder, 'user_defined_types' do
       }
     end
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    context "with namespace included" do
+      let(:expected) do
+        {
+          type: :record,
+          name: :system,
+          fields: [
+            { name: :user_ids, type: { type: :array, items: :int } },
+            { name: :group_ids, type: { type: :array, items: :int } }
+          ]
+        }
+      end
+      context "namespace in hash" do
+        subject(:schema_json) do
+          described_class.build do
+            define_type(:id_array, { namespace: 'test.foo' }, array(int))
+
+            record :system do
+              required :user_ids, :id_array
+              required :group_ids, 'test.foo.id_array'
+            end
+          end
+        end
+        it { is_expected.to be_json_eql(expected.to_json) }
+      end
+
+      context "namespace as string" do
+        subject(:schema_json) do
+          described_class.build do
+            define_type(:id_array, 'test.foo', array(int))
+
+            record :system do
+              required :user_ids, :id_array
+              required :group_ids, 'test.foo.id_array'
+            end
+          end
+        end
+        it { is_expected.to be_json_eql(expected.to_json) }
+      end
+
+      context "namespace included in name" do
+        subject(:schema_json) do
+          described_class.build do
+            define_type('test.foo.id_array', array(int))
+
+            record :system do
+              required :user_ids, :id_array
+              required :group_ids, 'test.foo.id_array'
+            end
+          end
+        end
+        it { is_expected.to be_json_eql(expected.to_json) }
+      end
+    end
   end
 
   context "user defined type from a file" do
@@ -39,5 +104,16 @@ describe Avro::Builder, 'user_defined_types' do
       }
     end
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    context "with namespace specified for user-defined type" do
+      subject(:schema_json) do
+        described_class.build do
+          record :with_date do
+            required :d, 'test.date'
+          end
+        end
+      end
+      it { is_expected.to be_json_eql(expected.to_json) }
+    end
   end
 end

--- a/spec/avro/dsl/test/date.rb
+++ b/spec/avro/dsl/test/date.rb
@@ -1,3 +1,3 @@
 namespace 'test'
 
-define_type(:date, int(logical_type: :date))
+type_macro :date, int(logical_type: :date)

--- a/spec/avro/dsl/test/date.rb
+++ b/spec/avro/dsl/test/date.rb
@@ -1,0 +1,1 @@
+define_type(:date, int(logical_type: :date))

--- a/spec/avro/dsl/test/date.rb
+++ b/spec/avro/dsl/test/date.rb
@@ -1,1 +1,3 @@
+namespace 'test'
+
 define_type(:date, int(logical_type: :date))


### PR DESCRIPTION
This change allows names to be associated with types that cannot usually be named in Avro schemas. This allows those types to be reused across DSL files.

Prime: @jturkel 