### PR TITLE
Allow generation of json files instead of avsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,10 +398,10 @@ Custom rake tasks can also be defined:
 require 'avro/builder/rake/avro_generate_task'
 Avro::Builder::Rake::AvroGenerateTask.new(name: :custom_gen,
                                           dependencies: [:load_app]) do |task|
+  task.filetype = :avsc
   task.root = '/path/to/dsl/files'
   task.load_paths << '/additional/dsl/files'
 end
-)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Custom rake tasks can also be defined:
 require 'avro/builder/rake/avro_generate_task'
 Avro::Builder::Rake::AvroGenerateTask.new(name: :custom_gen,
                                           dependencies: [:load_app]) do |task|
-  task.filetype = :avsc
+  task.filetype = 'avsc' # default option
   task.root = '/path/to/dsl/files'
   task.load_paths << '/additional/dsl/files'
 end

--- a/lib/avro/builder/rake/avro_generate_task.rb
+++ b/lib/avro/builder/rake/avro_generate_task.rb
@@ -9,11 +9,6 @@ module Avro
         attr_accessor :name, :task_namespace, :task_desc, :root,
                       :load_paths, :dependencies, :filetype
 
-        FILETYPES = {
-          avsc: '.avsc',
-          json: '.json'
-        }.freeze
-
         def initialize(name: :generate, dependencies: [])
           @name = name
           @task_namespace = :avro
@@ -21,7 +16,7 @@ module Avro
           @load_paths = []
           @root = "#{Rails.root}/avro/dsl" if defined?(Rails)
           @dependencies = dependencies
-          @filetype = :avsc
+          @filetype = 'avsc'
 
           yield self if block_given?
 
@@ -39,7 +34,7 @@ module Avro
               Avro::Builder.add_load_path(*[root, load_paths].flatten)
               Dir["#{root}/**/*.rb"].each do |dsl_file|
                 puts "Generating Avro schema from #{dsl_file}"
-                output_file = dsl_file.sub('/dsl/', '/schema/').sub(/\.rb$/, FILETYPES[filetype])
+                output_file = dsl_file.sub('/dsl/', '/schema/').sub(/\.rb$/, ".#{filetype}")
                 schema = Avro::Builder.build(filename: dsl_file)
                 FileUtils.mkdir_p(File.dirname(output_file))
                 File.write(output_file, schema.end_with?("\n") ? schema : schema << "\n")

--- a/lib/avro/builder/rake/avro_generate_task.rb
+++ b/lib/avro/builder/rake/avro_generate_task.rb
@@ -7,7 +7,12 @@ module Avro
       class AvroGenerateTask < ::Rake::TaskLib
 
         attr_accessor :name, :task_namespace, :task_desc, :root,
-                      :load_paths, :dependencies
+                      :load_paths, :dependencies, :filetype
+
+        FILETYPES = {
+          avsc: '.avsc',
+          json: '.json'
+        }.freeze
 
         def initialize(name: :generate, dependencies: [])
           @name = name
@@ -16,6 +21,7 @@ module Avro
           @load_paths = []
           @root = "#{Rails.root}/avro/dsl" if defined?(Rails)
           @dependencies = dependencies
+          @filetype = :avsc
 
           yield self if block_given?
 
@@ -33,7 +39,7 @@ module Avro
               Avro::Builder.add_load_path(*[root, load_paths].flatten)
               Dir["#{root}/**/*.rb"].each do |dsl_file|
                 puts "Generating Avro schema from #{dsl_file}"
-                output_file = dsl_file.sub('/dsl/', '/schema/').sub(/\.rb$/, '.avsc')
+                output_file = dsl_file.sub('/dsl/', '/schema/').sub(/\.rb$/, FILETYPES[filetype])
                 schema = Avro::Builder.build(filename: dsl_file)
                 FileUtils.mkdir_p(File.dirname(output_file))
                 File.write(output_file, schema.end_with?("\n") ? schema : schema << "\n")


### PR DESCRIPTION
As things stand, the schema files generated by the rake task are always `avsc` files. This PR adds support to specify which filetype we want the schemas to be in (`json`, for example).


Also removed a typo in the `README.md` file (extra parenthesis in the end of a code block).