### PR TITLE
arrays of inlined records

### DIFF
--- a/lib/avro/builder/record.rb
+++ b/lib/avro/builder/record.rb
@@ -3,6 +3,17 @@ module Avro
 
     class Record < Avro::Builder::Types::RecordType
       include Avro::Builder::Types::TopLevel
+
+      # This was copy-pasted; it's meant to be a proof-of-concept, not actually shippable code
+      def record(name = nil, options = {}, &block)
+        create_and_configure_builtin_type(
+          :record,
+          cache: cache,
+          internal: { _name: name, namespace: namespace },
+          options: options,
+          &block
+        )
+      end
     end
   end
 end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1107,6 +1107,76 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "array of records" do
+    subject(:schema_json) do
+      described_class.build do
+        record :array_of_records do
+          required :ary, :array, items: (record(:inlined_record) { required :name, :string })
+        end
+      end
+    end
+
+    let(:expected) do
+      {
+        type: :record,
+        name: :array_of_records,
+        fields: [{
+          name: :ary,
+          type: {
+            type: :array,
+            items: {
+              name: :inlined_record,
+              type: :record,
+              fields: [{ name: :name, type: :string }]
+            }
+          }
+        }]
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "record with array of records" do
+    subject(:schema_json) do
+      described_class.build do
+        record :array_of_records do
+          required :outer_record, :record do
+            required :ary, :array, items: (record(:inlined_record) { required :name, :string })
+          end
+        end
+      end
+    end
+
+    let(:expected) do
+      {
+        type: :record,
+        name: :array_of_records,
+        fields: [
+          {
+            name: :outer_record,
+            type: {
+              type: :record,
+              fields: [{
+                name: :ary,
+                type: {
+                  type: :array,
+                  items: {
+                    name: :inlined_record,
+                    type: :record,
+                    fields: [{ name: :name, type: :string }]
+                  }
+                }
+              }]
+            }
+          }
+        ]
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
   context "array without items type" do
     subject(:schema_json) do
       described_class.build do


### PR DESCRIPTION
@tjwp started trying to solve https://github.com/salsify/avro-builder/issues/34. The example in there wasn't too hard to implement (note that the code in this PR is totally just proof-of-concept, it's copy+pasted and **not meant to be shipped**); it's covered by the first spec in the diff. (I haven't tried the other suggestions in [@tjwp's post](https://github.com/salsify/avro-builder/issues/34#issuecomment-276159788), not sure what will happen. Will explore that after some more pressing issues are resolved.)

After getting this POC to work I wanted to explore a slightly more complicated scenario which is in the second spec in the diff; this is where I got really confused and could use some help. I would _expect_ both tests to fail with the same message and, when the implementation is written, for both tests to pass. The second test, however, seems to be exercising a completely different code path.

Before the implementation was written, the first test (`context "array of records"`) failed with:
```ruby
NoMethodError: undefined method `record' for #<Avro::Builder::Record:0x007f91653cac28>
./spec/avro/builder_spec.rb:1114:in `block (5 levels) in <top (required)>'
```

Again without the implementation code, the second test (`context "record with array of records"`) fails with a _different error entirely_:
```ruby
ArgumentError: wrong number of arguments (given 1, expected 0)
./spec/avro/builder_spec.rb:1145:in `block (6 levels) in <top (required)>'
```

Why should these two tests fail differently? The second one is initially red because the record is being given a name, but if you remove the name you just get a different failure:
```ruby
Expected equivalent JSON
Diff:

@@ -7,20 +7,12 @@
           {
             "name": "ary",
             "type": {
-              "items": {
-                "fields": [
-                  {
-                    "name": "name",
-                    "type": "string"
-                  }
-                ],
-                "name": "inlined_record",
-                "type": "record"
-              },
+              "items": "array_of_records",
               "type": "array"
             }
           }
         ],
+        "name": "__array_of_records_outer_record_record",
         "type": "record"
       }
     }

./spec/avro/builder_spec.rb:1177:in `block (3 levels) in <top (required)>'
```

Regardless of the name (that's a separate issue), I would expect these two tests to behave identically and exercise the same code. Do you have any insight as to why they're different?