### PR TITLE
Improve repeated file match handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-builder changelog
 
+## v0.14.1
+- File handling fixes.
+
 ## v0.14.0
 - Allow `filetype` to be specified in rake task to generate Avro JSON schema
   files.

--- a/lib/avro/builder/file_handler.rb
+++ b/lib/avro/builder/file_handler.rb
@@ -25,17 +25,22 @@ module Avro
         # a namespace then ensure that periods (.) are replaced by forward
         # slashes. E.g. for 'test.example' search for '/test/example.rb'.
         file_name = "/#{name.to_s.tr('.', '/').sub(/^\//, '').sub(/\.rb$/, '')}.rb"
-        matches = self.class.load_paths.flat_map do |load_path|
+        matches = real_load_paths.flat_map do |load_path|
           Dir["#{load_path}/**/*.rb"].select do |file_path|
             file_path.end_with?(file_name)
           end
-        end
+        end.uniq
         raise "Multiple matches: #{matches}" if matches.size > 1
         raise "File not found #{file_name}" if matches.empty?
 
         matches.first
       end
 
+      private
+
+      def real_load_paths
+        self.class.load_paths.map { |path| File.realpath(path) }.uniq
+      end
     end
   end
 end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.14.0'.freeze
+    VERSION = '0.14.1'.freeze
   end
 end

--- a/spec/avro/builder/file_handler_spec.rb
+++ b/spec/avro/builder/file_handler_spec.rb
@@ -85,6 +85,49 @@ describe Avro::Builder::FileHandler do
     end
   end
 
+  context "with duplicated paths" do
+    subject(:schema_json) do
+      Avro::Builder.build do
+        record :with_date do
+          required :dt, :date
+        end
+      end
+    end
+    let(:expected) do
+      {
+        type: :record,
+        name: :with_date,
+        fields: [
+          {
+            name: :dt,
+            type: {
+              type: :int,
+              logicalType: :date
+            }
+          }
+        ]
+      }
+    end
+
+    context "subpath" do
+      before do
+        Avro::Builder.add_load_path('spec/avro/dsl')
+        Avro::Builder.add_load_path('spec/avro/dsl/test')
+      end
+
+      it { is_expected.to be_json_eql(expected.to_json) }
+    end
+
+    context "normalization required" do
+      before do
+        Avro::Builder.add_load_path('spec/avro/dsl')
+        Avro::Builder.add_load_path(File.join(__dir__, '../dsl'))
+      end
+
+      it { is_expected.to be_json_eql(expected.to_json) }
+    end
+  end
+
   context "a file with a name that ends with a builtin type" do
     let(:file_path) { 'spec/avro/dsl/test/with_array.rb' }
     subject(:schema_json) { Avro::Builder.build(File.read(file_path)) }

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1847,7 +1847,7 @@ describe Avro::Builder do
           schema_json
         rescue => ex
         end
-        expect(ex.backtrace[1]).to start_with('spec/avro/dsl/test/invalid.rb:4:')
+        expect(ex.backtrace[1]).to match(/^.*spec\/avro\/dsl\/test\/invalid.rb:4:/)
       end
       # rubocop:enable Lint/HandleExceptions
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'avro/builder'
 
 RSpec.configure do |config|
   config.before do
+    Avro::Builder::DSL.load_paths.clear
     Avro::Builder.add_load_path('spec/avro/dsl')
   end
 end


### PR DESCRIPTION
Handle the following situations for load paths:
- a path and a subpath being specified
- two paths that correspond to the same `realpath`

Prime: @jturkel 