### PR TITLE
Allow types to be declared as abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-builder changelog
 
+## v0.15.0
+- Add support for declaring types as abstract.
+
 ## v0.14.1
 - File handling fixes.
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,25 @@ record :with_date_array
 end
 ```
 
+### Abstract Types
+
+Types can be declared as abstract in the DSL. Declaring a type as abstract
+prevents the rake task from generating an Avro JSON schema for the type.
+
+A type can be declared as abstract using either an option or a method in the
+DSL when defining the type:
+
+```ruby
+record :unique_id, abstract: true
+  required :uuid, :fixed, size: 38
+end
+
+enum :status do
+  symbols %w(valid invalid)
+  abstract true
+end
+```
+
 ### Type Macros
 
 `avro-builder` allows type macros to be defined that expand to types that
@@ -338,6 +357,9 @@ an explicit namespace option may be specified:
 type_macro :timestamp, long(logical_type: 'timestamp-millis'),
            namespace: 'com.my_company'
 ```
+
+Type macros are always marked as abstract and do not generate an Avro JSON
+schema file when using the rake task.
 
 ### Auto-loading and Imports
 

--- a/avro-builder.gemspec
+++ b/avro-builder.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'json_spec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.47.0'

--- a/lib/avro/builder.rb
+++ b/lib/avro/builder.rb
@@ -5,12 +5,17 @@ require 'avro/builder/schema_store'
 module Avro
   module Builder
 
+    # Accepts a string or block to eval and returns the Avro::Builder::DSL object
+    def self.build_dsl(str = nil, filename: nil, &block)
+      Avro::Builder::DSL.new(str, filename: filename, &block)
+    end
+
     # Accepts a string or block to eval to define a JSON schema
     def self.build(str = nil, filename: nil, &block)
       Avro::Builder::DSL.new(str, filename: filename, &block).to_json
     end
 
-    # Accepts a string or block to eval and returns an Avro::Schema
+    # Accepts a string or block to eval and returns an Avro::Schema object
     def self.build_schema(str = nil, filename: nil, &block)
       Avro::Builder::DSL.new(str, filename: filename, &block).as_schema
     end

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -38,6 +38,10 @@ module Avro
         end
       end
 
+      def abstract?
+        @last_object && @last_object.abstract?
+      end
+
       # Define an Avro schema record
       def record(name = nil, options = {}, &block)
         create_named_type(name, :record, options, &block)
@@ -92,7 +96,10 @@ module Avro
       def type_macro(name, type_object, options = {})
         raise "#{type_object.inspect} must be a type object" unless type_object.is_a?(Types::Type)
         raise "namespace cannot be included in name: #{name}" if name.to_s.index('.')
-        cache.add_type_by_name(type_object, name, options[:namespace] || namespace)
+        type_clone = type_object.clone
+        type_clone.send(:abstract=, true)
+        cache.add_type_by_name(type_clone, name, options[:namespace] || namespace)
+        @last_object = type_clone
       end
 
       private

--- a/lib/avro/builder/rake/avro_generate_task.rb
+++ b/lib/avro/builder/rake/avro_generate_task.rb
@@ -35,9 +35,17 @@ module Avro
               Dir["#{root}/**/*.rb"].each do |dsl_file|
                 puts "Generating Avro schema from #{dsl_file}"
                 output_file = dsl_file.sub('/dsl/', '/schema/').sub(/\.rb$/, ".#{filetype}")
-                schema = Avro::Builder.build(filename: dsl_file)
-                FileUtils.mkdir_p(File.dirname(output_file))
-                File.write(output_file, schema.end_with?("\n") ? schema : schema << "\n")
+                dsl = Avro::Builder.build_dsl(filename: dsl_file)
+                if dsl.abstract?
+                  if File.exist?(output_file)
+                    puts "... Removing #{output_file} for abstract type"
+                    FileUtils.rm(output_file)
+                  end
+                else
+                  schema = dsl.to_json
+                  FileUtils.mkdir_p(File.dirname(output_file))
+                  File.write(output_file, schema.end_with?("\n") ? schema : schema << "\n")
+                end
               end
             end
           end

--- a/lib/avro/builder/types/named_type.rb
+++ b/lib/avro/builder/types/named_type.rb
@@ -18,7 +18,7 @@ module Avro
 
         dsl_attribute_alias :type_aliases, :aliases
 
-        # This module most be included after options are defined
+        # This module must be included after options are defined
         include Avro::Builder::Types::NamedErrorHandling
 
         def name(value = nil)

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -8,7 +8,7 @@ module Avro
         include Avro::Builder::DslOptions
         include Avro::Builder::DslAttributes
 
-        dsl_attribute :logical_type
+        dsl_attributes :logical_type, :abstract
 
         attr_reader :avro_type_name
 
@@ -16,6 +16,10 @@ module Avro
           @avro_type_name = avro_type_name
           @cache = cache
           @field = field
+        end
+
+        def abstract?
+          !!abstract
         end
 
         def serialize(_reference_state)

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.14.1'.freeze
+    VERSION = '0.15.0'.freeze
   end
 end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.15.0'.freeze
+    VERSION = '0.15.0.rc0'.freeze
   end
 end

--- a/spec/avro/builder_build_dsl_spec.rb
+++ b/spec/avro/builder_build_dsl_spec.rb
@@ -1,0 +1,118 @@
+describe Avro::Builder, "#build_dsl" do
+
+  shared_examples_for "dsl for an abstact type" do
+    it { is_expected.to be_abstract }
+    its(:to_json) { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "record" do
+    let(:expected) do
+      {
+        type: :record,
+        name: :identifier,
+        fields: [
+          { type: :long, name: :id },
+          { type: :string, name: :name }
+        ]
+      }
+    end
+
+    context "abstract as an option" do
+      subject(:dsl) do
+        described_class.build_dsl do
+          record :identifier, abstract: true do
+            required :id, :long
+            required :name, :string
+          end
+        end
+      end
+
+      it_behaves_like "dsl for an abstact type"
+    end
+
+    context "abstract as a method" do
+      subject(:dsl) do
+        described_class.build_dsl do
+          record :identifier do
+            abstract true
+            required :id, :long
+            required :name, :string
+          end
+        end
+      end
+
+      it_behaves_like "dsl for an abstact type"
+    end
+  end
+
+  context "enum" do
+    let(:expected) do
+      { type: :enum, name: :letters, symbols: %w(A B C) }
+    end
+
+    context "abstract as an option" do
+      subject(:dsl) do
+        described_class.build_dsl do
+          enum :letters, symbols: %w(A B C), abstract: true
+        end
+      end
+
+      it_behaves_like "dsl for an abstact type"
+    end
+
+    context "abstract as a method" do
+      subject(:dsl) do
+        described_class.build_dsl do
+          enum :letters do
+            symbols %w(A B C)
+            abstract true
+          end
+        end
+      end
+
+      it_behaves_like "dsl for an abstact type"
+    end
+  end
+
+  context "fixed" do
+    let(:expected) do
+      { type: :fixed, name: :ssn, size: 11 }
+    end
+
+    context "abstract as an option" do
+      subject(:dsl) do
+        described_class.build_dsl do
+          fixed :ssn, size: 11, abstract: true
+        end
+      end
+
+      it_behaves_like "dsl for an abstact type"
+    end
+
+    context "abstract as a method" do
+      subject(:dsl) do
+        described_class.build_dsl do
+          fixed :ssn do
+            size 11
+            abstract true
+          end
+        end
+      end
+
+      it_behaves_like "dsl for an abstact type"
+    end
+  end
+
+  context "type macro" do
+    subject(:dsl) do
+      described_class.build_dsl do
+        type_macro :string_map, map(:string)
+      end
+    end
+    let(:expected) do
+      { type: :map, values: :string }
+    end
+
+    it_behaves_like "dsl for an abstact type"
+  end
+end

--- a/spec/avro/builder_user_type_macros_spec.rb
+++ b/spec/avro/builder_user_type_macros_spec.rb
@@ -1,4 +1,18 @@
 describe Avro::Builder, 'type_macros' do
+  context "self.build_dsl" do
+    subject(:dsl) do
+      described_class.build_dsl do
+        type_macro :ts, long(logical_type: 'timestamp-millis')
+      end
+    end
+    let(:expected) do
+      { type: :long, logicalType: 'timestamp-millis' }
+    end
+
+    it { is_expected.to be_abstract }
+    its(:to_json) { is_expected.to be_json_eql(expected.to_json) }
+  end
+
   context "without a type object" do
     let(:schema_json) do
       described_class.build do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'json_spec'
+require 'rspec/its'
 require 'simplecov'
 
 SimpleCov.start do


### PR DESCRIPTION
Avro JSON schema files are not generated for abstract types.

Type macros are always assumed to be abstract.

Prime: @jturkel 