### PR TITLE
Add some additional capabilities to namespace resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # avro-builder changelog
 
 ## v0.16.0
-- Add support for providing an explicit `namespace` on `extend`. Default lookup 
-  to current namespace before falling back on global search. 
+- Add support for providing an explicit `namespace` on `extend`. 
+- Default lookup to current namespace before falling back on global search. 
 
 ## v0.15.0
 - Add support for declaring types as abstract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-builder changelog
 
+## v0.16.0
+- Add support for providing an explicit `namespace` on `extend`. Default lookup 
+  to current namespace before falling back on global search. 
+
 ## v0.15.0
 - Add support for declaring types as abstract.
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,40 @@ record using `extends <record_name>`. This adds all of the fields from
 the referenced record to the current record. The current record may override
 fields in the record that it extends.
 
+```
+record :original do
+  required :first, :string
+  required :second, :int
+end
+
+record :extended do
+  extends :original
+  optional :first, :string
+end
+```
+
+Additionally you can provide a `namespace` to `extends` if necessary to remove ambiguity.
+
+```
+namespace 'com.newbie'
+
+record :original, namespace: 'com.og' do
+  required :first, :string
+  required :second, :int
+end
+
+record :original do
+  required :first, :string
+  required :second, :int
+end
+
+record :extended do
+  extends :original, namespace: 'com.og'
+  optional :first, :string
+end
+```
+
+
 ## Schema Store
 
 The `Avro::Builder::SchemaStore` can be used to load DSL files and return cached

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -121,7 +121,7 @@ module Avro
         file_path = if namespace
                       begin
                         find_file([namespace, name].join('.'))
-                      rescue FileNotFoundError => _
+                      rescue FileNotFoundError
                         find_file(name)
                       end
                     else

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -50,7 +50,7 @@ module Avro
       # Imports from the file with specified name fragment.
       def import(name)
         previous_namespace = namespace
-        result = eval_file(name, previous_namespace)
+        result = eval_file(name)
         namespace(previous_namespace)
         result
       end
@@ -117,7 +117,7 @@ module Avro
                                                          &block)
       end
 
-      def eval_file(name, namespace = nil)
+      def eval_file(name)
         file_path = if namespace
                       begin
                         find_file([namespace, name].join('.'))

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -50,7 +50,7 @@ module Avro
       # Imports from the file with specified name fragment.
       def import(name)
         previous_namespace = namespace
-        result = eval_file(name)
+        result = eval_file(name, previous_namespace)
         namespace(previous_namespace)
         result
       end
@@ -117,8 +117,16 @@ module Avro
                                                          &block)
       end
 
-      def eval_file(name)
-        file_path = find_file(name)
+      def eval_file(name, namespace = nil)
+        file_path = if namespace
+                      begin
+                        find_file([namespace, name].join('.'))
+                      rescue FileNotFoundError => _
+                        find_file(name)
+                      end
+                    else
+                      find_file(name)
+                    end
         instance_eval(File.read(file_path), file_path)
       end
     end

--- a/lib/avro/builder/file_handler.rb
+++ b/lib/avro/builder/file_handler.rb
@@ -19,6 +19,8 @@ module Avro
         File.read(find_file(name))
       end
 
+      FileNotFoundError = Class.new(StandardError)
+
       def find_file(name)
         # Ensure that the file_name that is searched for begins with a slash (/)
         # and ends with a .rb extension. Additionally, if the name contains
@@ -31,7 +33,7 @@ module Avro
           end
         end.uniq
         raise "Multiple matches: #{matches}" if matches.size > 1
-        raise "File not found #{file_name}" if matches.empty?
+        raise FileNotFoundError.new("File not found #{file_name}") if matches.empty?
 
         matches.first
       end

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -53,8 +53,8 @@ module Avro
 
         # Adds fields from the record with the specified name to the current
         # record.
-        def extends(name)
-          fields.merge!(cache.lookup_named_type(name, namespace).duplicated_fields)
+        def extends(name, options = {})
+          fields.merge!(cache.lookup_named_type(name, options.delete(:namespace) || namespace).duplicated_fields)
         end
 
         def to_h(reference_state = SchemaSerializerReferenceState.new)

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -1,5 +1,5 @@
 module Avro
   module Builder
-    VERSION = '0.15.0'.freeze
+    VERSION = '0.16.0'.freeze
   end
 end

--- a/spec/avro/builder/schema_store_spec.rb
+++ b/spec/avro/builder/schema_store_spec.rb
@@ -14,7 +14,7 @@ describe Avro::Builder::SchemaStore do
       end
 
       it "raises a file not found exception" do
-        expect { schema }.to raise_error(RuntimeError)
+        expect { schema }.to raise_error(::Avro::Builder::FileHandler::FileNotFoundError)
       end
     end
 

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1820,14 +1820,14 @@ describe Avro::Builder do
           namespace: 'test.namespace',
           type: :record,
           fields: [
-              {
-                  name: :foo,
-                  type: :string
-              },
-              {
-                  name: :bar,
-                  type: :string
-              }
+            {
+                name: :foo,
+                type: :string
+            },
+            {
+                name: :bar,
+                type: :string
+            }
           ]
       }
     end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1793,6 +1793,48 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "extends from explicit namespace" do
+    subject(:schema_json) do
+      described_class.build do
+        namespace 'test.namespace'
+
+        record :original, namespace: 'test.extended' do
+          required :foo, :string
+          required :bar, :string
+        end
+
+        record :original do
+          required :bop, :string
+          required :baz, :string
+        end
+
+        record :extended do
+          extends :original, namespace: 'test.extended'
+        end
+      end
+    end
+
+    let(:expected) do
+      {
+          name: :extended,
+          namespace: 'test.namespace',
+          type: :record,
+          fields: [
+              {
+                  name: :foo,
+                  type: :string
+              },
+              {
+                  name: :bar,
+                  type: :string
+              }
+          ]
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
   context "recursive example" do
     # this is an example from the Avro specification
     subject(:schema_json) do

--- a/spec/avro/dsl/test/external_type.rb
+++ b/spec/avro/dsl/test/external_type.rb
@@ -1,2 +1,2 @@
-namespace :test
+namespace 'test'
 fixed :external_type, size: 2

--- a/spec/avro/dsl/test/external_type.rb
+++ b/spec/avro/dsl/test/external_type.rb
@@ -1,2 +1,2 @@
-namespace 'test'
+namespace :test
 fixed :external_type, size: 2


### PR DESCRIPTION
Fix proposes a change to allow `extends` to explicitly provide a `namespace` and changes default object lookup to use the current `namespace` before falling back to global search across namespaces (this is the current behavior). 