### PR TITLE
Add support for enum defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-builder changelog
 
+## v0.17.0 (unreleased)
+- Add support for enum defaults introduced in Avro v1.10.0.
+
 ## v0.16.2
 - Allow avro version up to v1.10.x. Support will be added for new
   functionality in Avro v1.10 in a later release.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ fixed :g, size: 8
 enum :e, :X, :Y, :Z
 enum :d, symbols: [:A, :B]
 
+# defaults can be set for enums with Ruby Avro v1.10.0
+enum :c, symbols: [:A, :B], default: :A
+
 record :my_record_with_named do
   required :f_ref, :f
   required :fixed_inline, :fixed, size: 9

--- a/lib/avro/builder/types/enum_type.rb
+++ b/lib/avro/builder/types/enum_type.rb
@@ -5,7 +5,7 @@ module Avro
     module Types
       class EnumType < NamedType
 
-        dsl_attribute :doc
+        dsl_attributes :doc, :default
 
         dsl_attribute :symbols do |*values|
           # Define symbols explicitly to support values as a splat or single array
@@ -27,12 +27,19 @@ module Avro
         def validate!
           super
           validate_required_attribute!(:symbols)
+          validate_enum_default!
         end
 
         private
 
+        def validate_enum_default!
+          if !default.nil? && !symbols.map(&:to_sym).include?(default.to_sym)
+            raise AttributeError.new("enum default '#{default}' must be one of the enum symbols: #{symbols}")
+          end
+        end
+
         def serialized_attributes
-          { symbols: symbols, doc: doc }
+          { symbols: symbols, doc: doc, default: default }
         end
       end
     end

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -2,6 +2,6 @@
 
 module Avro
   module Builder
-    VERSION = '0.16.2'
+    VERSION = '0.17.0'
   end
 end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe Avro::Builder do
+  let(:schema) { Avro::Schema.parse(schema_json) }
+
   context "primitive types" do
     describe "#type" do
       subject(:schema_json) do
@@ -151,6 +153,10 @@ describe Avro::Builder do
     end
 
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    it "sets the default on the schema", :enum_default do
+      expect(schema.default).to eq('ONE')
+    end
   end
 
   context "enum with symbols in hash" do

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -134,6 +134,25 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "enum type with default" do
+    subject(:schema_json) do
+      described_class.build do
+        enum :enum1, :ONE, :TWO, default: :ONE
+      end
+    end
+
+    let(:expected) do
+      {
+        name: :enum1,
+        type: :enum,
+        symbols: [:ONE, :TWO],
+        default: :ONE
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
   context "enum with symbols in hash" do
     subject(:schema_json) do
       described_class.build do
@@ -147,6 +166,64 @@ describe Avro::Builder do
         type: :enum,
         doc: 'Uses hash',
         symbols: [:ONE, :TWO]
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "enum with symbols in hash and default" do
+    subject(:schema_json) do
+      described_class.build do
+        enum :enum1, symbols: [:ONE, :TWO], doc: 'Uses hash', default: :ONE
+      end
+    end
+
+    let(:expected) do
+      {
+        name: :enum1,
+        type: :enum,
+        doc: 'Uses hash',
+        symbols: [:ONE, :TWO],
+        default: :ONE
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "enum with string symbols and symbol default" do
+    subject(:schema_json) do
+      described_class.build do
+        enum :enum1, symbols: ['ONE', 'TWO'], default: :ONE
+      end
+    end
+
+    let(:expected) do
+      {
+        name: :enum1,
+        type: :enum,
+        symbols: [:ONE, :TWO],
+        default: :ONE
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
+  context "enum with symbols and string default" do
+    subject(:schema_json) do
+      described_class.build do
+        enum :enum1, symbols: [:ONE, :TWO], default: 'ONE'
+      end
+    end
+
+    let(:expected) do
+      {
+        name: :enum1,
+        type: :enum,
+        symbols: [:ONE, :TWO],
+        default: :ONE
       }
     end
 
@@ -197,6 +274,28 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "enum with symbols splat and default" do
+    subject(:schema_json) do
+      described_class.build do
+        enum :enum3 do
+          symbols :A, :B
+          default :B
+        end
+      end
+    end
+
+    let(:expected) do
+      {
+        name: :enum3,
+        type: :enum,
+        symbols: [:A, :B],
+        default: :B
+      }
+    end
+
+    it { is_expected.to be_json_eql(expected.to_json) }
+  end
+
   context "enum with symbols array" do
     subject(:schema_json) do
       described_class.build do
@@ -217,6 +316,22 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
+  context "enum with invalid default" do
+    subject(:schema_json) do
+      described_class.build do
+        enum :enum_invalid_default do
+          symbols :A, :B
+          default :C
+        end
+      end
+    end
+
+    it "raises an error" do
+      expect { schema_json }.to raise_error(Avro::Builder::AttributeError,
+                                            /enum default 'C' must be one of the enum symbols:/)
+    end
+  end
+
   context "enum type_name as option" do
     subject(:schema_json) do
       described_class.build do
@@ -224,14 +339,6 @@ describe Avro::Builder do
           symbols :A, :B
         end
       end
-    end
-
-    let(:expected) do
-      {
-        name: :enum3,
-        type: :enum,
-        symbols: [:A, :B]
-      }
     end
 
     it "raises an error" do
@@ -247,14 +354,6 @@ describe Avro::Builder do
           symbols :A, :B
         end
       end
-    end
-
-    let(:expected) do
-      {
-        name: :enum3,
-        type: :enum,
-        symbols: [:A, :B]
-      }
     end
 
     it "raises an error" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,4 +16,16 @@ RSpec.configure do |config|
     Avro::Builder::DSL.load_paths.clear
     Avro::Builder.add_load_path('spec/avro/dsl')
   end
+
+  enum_default_supported = Avro::Schema::EnumSchema.instance_methods.include?(:default)
+
+  config.around(:each, :enum_default) do |example|
+    # The Avro gem does not correctly set a version :(
+    # So check for functionality for examples that require it.
+    if enum_default_supported
+      example.run
+    else
+      skip "enum_default not supported by this Avro version"
+    end
+  end
 end


### PR DESCRIPTION
Support for enum defaults was added to the avro gem in v1.10.0.
