### PR TITLE
Add test coverage for parsing aliases

### DIFF
--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -258,6 +258,10 @@ describe Avro::Builder do
     end
 
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    it "sets aliases for the type", :aliases do
+      expect(schema.aliases).to eq(['Foo', 'Bar'])
+    end
   end
 
   context "enum with symbols splat" do
@@ -455,6 +459,10 @@ describe Avro::Builder do
     end
 
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    it "sets aliases for the schema", :aliases do
+      expect(schema.aliases).to eq(['MoreThanSix'])
+    end
   end
 
   context "fixed type with type_aliases via block" do
@@ -1966,6 +1974,10 @@ describe Avro::Builder do
     end
 
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    it "sets an alias for the record", :aliases do
+      expect(schema.aliases).to eq(['LinkedLongs'])
+    end
   end
 
   context "a field with aliases and a type with aliases" do
@@ -2001,6 +2013,10 @@ describe Avro::Builder do
     end
 
     it { is_expected.to be_json_eql(expected.to_json) }
+
+    it "sets aliases for fields", :aliases do
+      expect(schema.fields.first.aliases).to eq(['field_alias'])
+    end
   end
 
   context "doc option on field" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ RSpec.configure do |config|
   end
 
   enum_default_supported = Avro::Schema::EnumSchema.instance_methods.include?(:default)
+  aliases_supported = Avro::Schema::NamedSchema.instance_methods.include?(:aliases)
 
   config.around(:each, :enum_default) do |example|
     # The Avro gem does not correctly set a version :(
@@ -26,6 +27,14 @@ RSpec.configure do |config|
       example.run
     else
       skip "enum_default not supported by this Avro version"
+    end
+  end
+
+  config.around(:each, :aliases) do |example|
+    if aliases_supported
+      example.run
+    else
+      skip "aliases not supported by this Avro version"
     end
   end
 end


### PR DESCRIPTION
The Ruby Avro v1.10.0 release added support for aliases. Aliases were part of the Avro specification for a while, but were not supported by the Ruby implementation until now.

The DSL in this gem supported aliases. Now that the Ruby implementation also parses them as part of the schema it made sense to add tests to verify that they are configured as expected.

Just new test examples, no library change.