### PR TITLE
Use MultiJson to encode schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # avro-builder changelog
 
-## Unreleased
+## v1.0.0 (unreleased)
 - Drop support for Avro < 1.9.
 - Drop support for Ruby < 2.6.
 - Add Ruby 3.0 support.
+- Bug fix: Use multi_json to encode schemas and ensure that a JSON encoder
+  is always present.
 
 ## v0.17.0
 - Add support for enum defaults introduced in Avro v1.10.0.

--- a/avro-builder.gemspec
+++ b/avro-builder.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency 'avro', '>= 1.9.0', '< 1.11'
+  spec.add_runtime_dependency 'multi_json'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'avro'
+require 'multi_json'
 require 'avro/builder/errors'
 require 'avro/builder/dsl_options'
 require 'avro/builder/dsl_attributes'
@@ -77,7 +78,7 @@ module Avro
       # Return the last schema object processed as an Avro JSON schema
       def to_json(validate: true, pretty: true)
         hash = to_h
-        (pretty ? JSON.pretty_generate(hash) : hash.to_json).tap do |json|
+        MultiJson.dump(hash, { pretty: pretty }).tap do |json|
           # Uncomment the next line to debug:
           # puts json
           # Parse the schema to validate before returning

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -2,6 +2,6 @@
 
 module Avro
   module Builder
-    VERSION = '0.17.0'
+    VERSION = '1.0.0'
   end
 end


### PR DESCRIPTION
Previous version of avro-builder rely on the `json` gem being loaded without explicitly requiring it. Behavior changed somewhere between ruby 2.6.2 and ruby 2.6.5 so that `json` is no longer loaded without an explicit require.

One option would be to `require 'json'` but the `avro` gem already depends on `multi_json`. Since `multi_json` is now referenced directly it is declared as a dependency here, but should also be present for any current users of the gem. 

Using `multi_json` provides more flexibility for users of the gem, and makes the JSON encoding code here slightly cleaner.

Fixes #55 