### PR TITLE
Pretty print generated schemas in Rails apps without oj or yajl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-builder changelog
 
+## v1.0.1
+- Bug fix: Fix pretty formatting of schemas for Rails applications that don't 
+  use oj or yajl by removing the dependency on multi_json.
+
 ## v1.0.0
 - Drop support for Avro < 1.9.
 - Drop support for Ruby < 2.6.

--- a/avro-builder.gemspec
+++ b/avro-builder.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency 'avro', '>= 1.9.0', '< 1.11'
-  spec.add_runtime_dependency 'multi_json'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/avro/builder/dsl.rb
+++ b/lib/avro/builder/dsl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'avro'
-require 'multi_json'
+require 'json'
 require 'avro/builder/errors'
 require 'avro/builder/dsl_options'
 require 'avro/builder/dsl_attributes'
@@ -78,7 +78,7 @@ module Avro
       # Return the last schema object processed as an Avro JSON schema
       def to_json(validate: true, pretty: true)
         hash = to_h
-        MultiJson.dump(hash, { pretty: pretty }).tap do |json|
+        (pretty ? JSON.pretty_generate(hash) : hash.to_json).tap do |json|
           # Uncomment the next line to debug:
           # puts json
           # Parse the schema to validate before returning

--- a/lib/avro/builder/version.rb
+++ b/lib/avro/builder/version.rb
@@ -2,6 +2,6 @@
 
 module Avro
   module Builder
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -839,7 +839,6 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
-
   context "record with repeated definition of inline named fix" do
     subject(:schema_json) do
       described_class.build do
@@ -865,7 +864,6 @@ describe Avro::Builder do
       expect { schema_json }.to raise_error(Avro::Builder::DuplicateDefinitionError)
     end
   end
-
 
   context "record with type references" do
     subject(:schema_json) do
@@ -1685,7 +1683,6 @@ describe Avro::Builder do
     it { is_expected.to be_json_eql(expected.to_json) }
   end
 
-
   context "inline, named, nested record" do
     subject(:schema_json) do
       described_class.build do
@@ -2187,5 +2184,17 @@ describe Avro::Builder do
 
       it_behaves_like "it reports error location in the stack trace"
     end
+  end
+
+  context "pretty printing" do
+    subject(:schema_json) do
+      described_class.build do
+        type(:string)
+      end
+    end
+
+    let(:expected) { { type: :string } }
+
+    it { is_expected.to eq("{\n  \"type\": \"string\"\n}") }
   end
 end


### PR DESCRIPTION
See #58 for details but I'm removing the multi_json dependency since this breaks pretty printing in Rails apps without oj or yajl.
