### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jturkel @rlburkes @tjwp


### PR DESCRIPTION
Adding current Owners from `rubygems` with a few exceptions as decided internally.

Will add branch protection once this merges.

prime @askreet 
cc @jturkel 