### PR TITLE
Don't silently ignore invalid type options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add support for field `order` attribute in serialized output.
+- Raise an error when invalid options are passed to a type instead of silently ignoring them.
 
 ## v2.1.0
 - Add support for Avro 1.12.

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -14,19 +14,14 @@ module Avro
       include Avro::Builder::Aliasable
       include Avro::Builder::AnonymousTypes
 
-      INTERNAL_ATTRIBUTES = [:optional_field].to_set.freeze
-
       # These attributes may be set as options or via a block in the DSL
       dsl_attributes :doc, :default, :order
 
-      def initialize(name:, avro_type_or_name:, record:, cache:, internal: {}, options: {}, &block)
+      def initialize(name:, avro_type_or_name:, record:, cache:, optional:, options: {}, &block)
         @cache = cache
         @record = record
         @name = name.to_s
-
-        internal.each do |key, value|
-          send("#{key}=", value) if INTERNAL_ATTRIBUTES.include?(key)
-        end
+        @optional_field = optional
 
         type_options = options.dup
         options.keys.each do |key|

--- a/lib/avro/builder/field.rb
+++ b/lib/avro/builder/field.rb
@@ -36,10 +36,11 @@ module Avro
         # Find existing Type or build a new instance of a builtin Type using
         # the supplied block
         @field_type = type_lookup(avro_type_or_name, namespace) do |avro_type_name|
+          type_internal = NAMED_TYPES.include?(avro_type_name.to_s) ? { type_namespace: namespace } : {}
           create_and_configure_builtin_type(avro_type_name,
                                             field: self,
                                             cache: cache,
-                                            internal: internal,
+                                            internal: type_internal,
                                             validate_type: false,
                                             options: type_options)
         end

--- a/lib/avro/builder/type_factory.rb
+++ b/lib/avro/builder/type_factory.rb
@@ -6,8 +6,8 @@ module Avro
     # This concern is used by classes that create new Type instances.
     module TypeFactory
 
-      NAMED_TYPES = ['enum', 'fixed', 'record'].map(&:freeze).to_set.freeze
-      COMPLEX_TYPES = ['array', 'enum', 'fixed', 'map', 'record', 'union'].map(&:freeze).to_set.freeze
+      NAMED_TYPES = ['enum', 'fixed', 'record'].to_set.freeze
+      COMPLEX_TYPES = ['array', 'enum', 'fixed', 'map', 'record', 'union'].to_set.freeze
       BUILTIN_TYPES = Avro::Schema::PRIMITIVE_TYPES.union(COMPLEX_TYPES).freeze
 
       private

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -13,11 +13,9 @@ module Avro
         dsl_attribute :doc
         dsl_attribute_alias :type_doc, :doc
 
-        def initialize(name = nil, cache:, options: {}, field: nil, &block)
+        def initialize(name = nil, cache:, field: nil, &block)
           super(cache: cache, field: field)
           @name = name
-
-          configure_options(options)
           instance_eval(&block) if block_given?
         end
 

--- a/lib/avro/builder/types/record_type.rb
+++ b/lib/avro/builder/types/record_type.rb
@@ -29,7 +29,7 @@ module Avro
                                                avro_type_or_name: avro_type_or_name,
                                                record: self,
                                                cache: cache,
-                                               internal: { type_namespace: namespace },
+                                               optional: false,
                                                options: options,
                                                &block)
           add_field(new_field)
@@ -42,8 +42,7 @@ module Avro
                                                avro_type_or_name: avro_type_or_name,
                                                record: self,
                                                cache: cache,
-                                               internal: { type_namespace: namespace,
-                                                           optional_field: true },
+                                               optional: true,
                                                options: options,
                                                &block)
           add_field(new_field)

--- a/lib/avro/builder/types/type.rb
+++ b/lib/avro/builder/types/type.rb
@@ -35,7 +35,7 @@ module Avro
 
         def configure_options(options = {})
           options.each do |key, value|
-            send("#{key}=", value) if dsl_option?(key)
+            send("#{key}=", value)
           end
         end
 

--- a/spec/avro/builder_logical_types_spec.rb
+++ b/spec/avro/builder_logical_types_spec.rb
@@ -217,9 +217,7 @@ describe Avro::Builder, 'logical_types' do
         with_decimal_validation do
           # Avro v1.11.0 does not yet validate fixed decimals
           it "relies on Avro schema parse to validate" do
-            expect do
-              schema
-            end.not_to raise_error(Avro::SchemaParseError)
+            schema
           end
         end
       end

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -575,6 +575,22 @@ describe Avro::Builder do
     end
   end
 
+  context "invalid option on a record field" do
+    let(:schema_json) do
+      described_class.build do
+        record :outer do
+          required :inner, :record, bogus: true do
+            required :s, :string
+          end
+        end
+      end
+    end
+
+    it "raises an error" do
+      expect { schema_json }.to raise_error(NoMethodError, /bogus/)
+    end
+  end
+
   context "record" do
     subject(:schema_json) do
       described_class.build do

--- a/spec/avro/builder_spec.rb
+++ b/spec/avro/builder_spec.rb
@@ -561,6 +561,20 @@ describe Avro::Builder do
     end
   end
 
+  context "invalid option on a type" do
+    let(:schema_json) do
+      described_class.build do
+        record :rec do
+          required :s, :string, bogus: true
+        end
+      end
+    end
+
+    it "raises an error" do
+      expect { schema_json }.to raise_error(NoMethodError, /bogus/)
+    end
+  end
+
   context "record" do
     subject(:schema_json) do
       described_class.build do


### PR DESCRIPTION
Previously, `Type#configure_options` silently skipped any option that wasn't a recognized DSL option. This masked bugs where invalid or misspelled options would be quietly dropped.  Fixing this was pretty easy because we only need to propagate the `type_namespace` option to fields with named types.

While I was in there, I removed the redundant call to `configure_options` in the `RecordType` constructor and fixed an RSpec warning about usage of `not_to raise_error` masking other problems.