### PR TITLE
Upgrade rake

### DIFF
--- a/avro-builder.gemspec
+++ b/avro-builder.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'json_spec'
   spec.add_development_dependency 'overcommit'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rspec_junit_formatter'


### PR DESCRIPTION
The release failed with the following error due to an old version of rake:

```
NoMethodError: undefined method `=~' for an instance of Proc
/home/jenkins/.rbenv/versions/3.3.10/bin/bundle:25:in `load'
/home/jenkins/.rbenv/versions/3.3.10/bin/bundle:25:in `<main>'
(See full trace by running task with --trace)
```

Upgrading to a more modern version of Rake fixes the problem.